### PR TITLE
Fix to allow usage of analyze_replay_file using only import carball

### DIFF
--- a/carball/__init__.py
+++ b/carball/__init__.py
@@ -1,1 +1,2 @@
 from carball.decompile_replays import decompile_replay
+from carball.decompile_replays import analyze_replay_file


### PR DESCRIPTION
Fixes issue where the example in the README.md does not work.

Without, the example on the README.md returns:

```
AttributeError: module 'carball' has no attribute 'analyze_replay_file'
```