### PR TITLE
Chore/allow protoc path from env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ replays/
 venv/
 /**/generated/**/*.py
 output
+.env

--- a/utils/create_proto.py
+++ b/utils/create_proto.py
@@ -14,6 +14,9 @@ proto_dir = os.path.join(current_dir, 'carball', 'generated')
 
 
 def get_proto():
+    if os.getenv('PROTOC_PATH'):
+        return os.getenv('PROTOC_PATH')
+
     if is_windows():
         return os.path.join(proto_dir, 'protoc.exe')
     else:

--- a/utils/tests/test_create_proto.py
+++ b/utils/tests/test_create_proto.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from ..create_proto import get_proto
+
+
+class GetProtoTests(unittest.TestCase):
+    @patch.dict(os.environ, {'PROTOC_PATH': '/foo/bar/protoc'})
+    def test_with_env_var(self):
+        protoc_path = get_proto()
+        self.assertEqual(protoc_path, '/foo/bar/protoc')
+
+    @patch('utils.create_proto.is_windows', return_value=True)
+    def test_windows(self, is_windows):
+        self.assertIsNone(os.getenv('PROTOC_PATH'))
+        self.assertTrue(is_windows())
+
+        protoc_path = get_proto()
+        self.assertTrue(protoc_path.endswith('protoc.exe'))
+
+    @patch('utils.create_proto.is_windows', return_value=False)
+    def test_is_not_windows(self, is_windows):
+        self.assertIsNone(os.getenv('PROTOC_PATH'))
+        self.assertFalse(is_windows())
+
+        protoc_path = get_proto()
+        self.assertTrue(protoc_path.endswith('protoc'))


### PR DESCRIPTION
Not sure if the included binary actually runs on OSX, but simple change to allow setting of path to the platform specific binary via environment variable.