### PR TITLE
Run rattle trap in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Decompile and analyze a replay:
 import carball
 
 manager = carball.analyze_replay_file('9EB5E5814D73F55B51A1BD9664D4CBF3.replay', 
-                                      '9EB5E5814D73F55B51A1BD9664D4CBF3.json', 
+                                      output_path='9EB5E5814D73F55B51A1BD9664D4CBF3.json', 
                                       overwrite=True)
 proto_game = manager.get_protobuf_data()
 
@@ -29,7 +29,7 @@ Just decompile a replay to a JSON object:
 import carball
 
 _json = carball.decompile_replay('9EB5E5814D73F55B51A1BD9664D4CBF3.replay', 
-                                '9EB5E5814D73F55B51A1BD9664D4CBF3.json', 
+                                output_path='9EB5E5814D73F55B51A1BD9664D4CBF3.json', 
                                 overwrite=True)
 ```
 

--- a/carball/decompile_replays.py
+++ b/carball/decompile_replays.py
@@ -9,13 +9,14 @@ from carball.extras.per_goal_analysis import PerGoalAnalysis
 from carball.json_parser.sanity_check.sanity_check import SanityChecker
 from carball.json_parser.game import Game
 from carball.controls.controls import ControlsCreator
+from carball.rattletrap import run_rattletrap
 
 
 logger = logging.getLogger(__name__)
 BASE_DIR = os.path.dirname(__file__)
 
 
-def decompile_replay(replay_path, output_path, overwrite=True):
+def decompile_replay(replay_path, output_path: str=None, overwrite=True):
     """
     Takes a path to the replay and outputs the json of that replay.
 
@@ -34,22 +35,12 @@ def decompile_replay(replay_path, output_path, overwrite=True):
         binary = [f for f in binaries if 'osx' in f][0]
     else:
         raise Exception('Unknown platform, unable to process replay file.')
-    output_dirs = os.path.dirname(output_path)
-    if not os.path.isdir(output_dirs) and output_dirs != '':
-        os.makedirs(output_dirs)
-    if overwrite or not os.path.isfile(output_path):
-        cmd = [os.path.join(os.path.join(BASE_DIR, 'rattletrap'), '{}'.format(binary)), '--compact', '-i',
-               replay_path,
-               '--output',
-               output_path]
-        logger.debug(" ".join(cmd))
-        subprocess.check_output(cmd)
-    with open(output_path, encoding="utf8") as f:
-        _json = json.load(f)
+    print(output_path)
+    _json = run_rattletrap.decompile_replay(replay_path, output_path)
     return _json
 
 
-def analyze_replay_file(replay_path: str, output_path: str, overwrite=True, controls: ControlsCreator=None,
+def analyze_replay_file(replay_path: str, output_path: str=None, overwrite=True, controls: ControlsCreator=None,
                         sanity_check: SanityChecker=None, analysis_per_goal=False):
     """
     Decompile and analyze a replay file.
@@ -62,7 +53,7 @@ def analyze_replay_file(replay_path: str, output_path: str, overwrite=True, cont
     :param analysis_per_goal: Runs the analysis per a goal instead of the replay as a whole
     :return: AnalysisManager of game with analysis.
     """
-    _json = decompile_replay(replay_path, output_path, overwrite=overwrite)
+    _json = decompile_replay(replay_path, output_path=output_path, overwrite=overwrite)
     game = Game()
     game.initialize(loaded_json=_json)
     # get_controls(game)  # TODO: enable and optimise.

--- a/carball/decompile_replays.py
+++ b/carball/decompile_replays.py
@@ -35,9 +35,7 @@ def decompile_replay(replay_path, output_path: str=None, overwrite=True):
         binary = [f for f in binaries if 'osx' in f][0]
     else:
         raise Exception('Unknown platform, unable to process replay file.')
-    print(output_path)
-    _json = run_rattletrap.decompile_replay(replay_path, output_path)
-    return _json
+    return run_rattletrap.decompile_replay(replay_path, output_path)
 
 
 def analyze_replay_file(replay_path: str, output_path: str=None, overwrite=True, controls: ControlsCreator=None,

--- a/carball/rattletrap/run_rattletrap.py
+++ b/carball/rattletrap/run_rattletrap.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
-def create_rattletrap_command(replay_path: str, output_path: str=None, overwrite: bool=True) -> List[str]:
+def create_rattletrap_command(replay_path: str, output_path: str, overwrite: bool=True) -> List[str]:
     """
     Takes a path to the replay and outputs the json of that replay.
 
@@ -30,7 +30,7 @@ def create_rattletrap_command(replay_path: str, output_path: str=None, overwrite
         raise Exception('Unknown platform, unable to process replay file.')
     cmd = [os.path.join(os.path.join(BASE_DIR, 'rattletrap'), '{}'.format(binary)), '--compact', '-i',
            replay_path]
-    if output_path is not None:
+    if output_path:
         output_dirs = os.path.dirname(output_path)
         if not os.path.isdir(output_dirs) and output_dirs != '':
             os.makedirs(output_dirs)
@@ -40,17 +40,20 @@ def create_rattletrap_command(replay_path: str, output_path: str=None, overwrite
     return cmd
 
 
-def run_rattletrap_command(command: List[str], output_path: str=None):
-    output = subprocess.check_output(command)
-    if output_path is not None:
+def run_rattletrap_command(command: List[str], output_path: str):
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+    output = proc.stdout.read()
+    if output:
+        output = output.decode('utf8')
+    if output_path:
         with open(output_path, encoding="utf8") as f:
             _json = json.load(f)
     else:
-        _json = json.load(output)
+        _json = json.loads(output)
     return _json
 
 
-def decompile_replay(replay_path: str, output_path: str=None, overwrite: bool=True):
+def decompile_replay(replay_path: str, output_path: str, overwrite: bool=True):
     """
     Takes a path to the replay and outputs the json of that replay.
 

--- a/carball/tests/game_creation_test.py
+++ b/carball/tests/game_creation_test.py
@@ -14,7 +14,7 @@ class DBTest(unittest.TestCase):
         local = self
 
         def test(replay, file_path):
-            json_object = decompile_replays.decompile_replay(replay, file_path)
+            json_object = decompile_replays.decompile_replay(replay, output_path=file_path)
             game = Game()
             game.initialize(loaded_json=json_object)
             info = game.game_info


### PR DESCRIPTION
Updated the rattletrap branch so that it can be ran without an output file.