### PR TITLE
Fix/Add support to crossplatform parties

### DIFF
--- a/carball/json_parser/game.py
+++ b/carball/json_parser/game.py
@@ -304,7 +304,12 @@ class Game:
                             unique_id = str(
                                 actor_data['Engine.PlayerReplicationInfo:UniqueId']['unique_id']['remote_id'][
                                     actor_type])
-                            leader = str(actor_data["TAGame.PRI_TA:PartyLeader"]["party_leader"]["id"][0][actor_type])
+                            leader_actor_type = list(
+                                actor_data["TAGame.PRI_TA:PartyLeader"]["party_leader"]["id"][0].keys()
+                            )[0]
+                            leader = str(
+                                actor_data["TAGame.PRI_TA:PartyLeader"]["party_leader"]["id"][0][leader_actor_type]
+                            )
                             if leader in parties:
                                 if unique_id not in parties[leader]:
                                     parties[leader].append(unique_id)

--- a/carball/json_parser/player.py
+++ b/carball/json_parser/player.py
@@ -124,10 +124,8 @@ class Player:
         self.party_leader = actor_data.get('TAGame.PRI_TA:PartyLeader', None)
         try:
             if self.party_leader is not None:
-                actor_type = \
-                    list(actor_data["Engine.PlayerReplicationInfo:UniqueId"]['unique_id']['remote_id'].keys())[
-                        0]
-                self.party_leader = str(self.party_leader['party_leader']['id'][0][actor_type])
+                leader_actor_type = list(self.party_leader['party_leader']['id'][0].keys())[0]
+                self.party_leader = str(self.party_leader['party_leader']['id'][0][leader_actor_type])
         except KeyError:
             logger.warning('Could not set player party leader for:', self.name)
             self.party_leader = None

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -83,7 +83,8 @@ def get_complex_replay_list():
         'https://cdn.discordapp.com/attachments/493849514680254468/496180938968137749/FAKE_BOTS_SkyBot.replay',
         'https://cdn.discordapp.com/attachments/493849514680254468/497149910999891969/NEGATIVE_WASTED_COLLECTION.replay',
         'https://cdn.discordapp.com/attachments/493849514680254468/497191273619259393/WASTED_BOOST_WHILE_SUPER_SONIC.replay',
-        'https://cdn.discordapp.com/attachments/493849514680254468/501630263881760798/OCE_RLCS_7_CARS.replay'
+        'https://cdn.discordapp.com/attachments/493849514680254468/501630263881760798/OCE_RLCS_7_CARS.replay',
+        'https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay'
     ]
 
 
@@ -162,6 +163,8 @@ def get_raw_replays():
         # error cases
         "UNICODE_ERROR": [
             "https://cdn.discordapp.com/attachments/493849514680254468/493880540802449462/UnicodeEncodeError.replay"],
+        "CROSSPLATFORM_PARTY_LEADER_ERROR": [
+            "https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay"],
     }
 
 


### PR DESCRIPTION
During parsing of replays with cross platform parties, errors were happening due  to an assumption that actor type was equal to leader actor type.  This PR fixes that.

