### PR TITLE
Add fix for party leader parsing and system id 0 update

### DIFF
--- a/carball/json_parser/game.py
+++ b/carball/json_parser/game.py
@@ -304,17 +304,21 @@ class Game:
                             unique_id = str(
                                 actor_data['Engine.PlayerReplicationInfo:UniqueId']['unique_id']['remote_id'][
                                     actor_type])
-                            leader_actor_type = list(
-                                actor_data["TAGame.PRI_TA:PartyLeader"]["party_leader"]["id"][0].keys()
-                            )[0]
-                            leader = str(
-                                actor_data["TAGame.PRI_TA:PartyLeader"]["party_leader"]["id"][0][leader_actor_type]
-                            )
-                            if leader in parties:
-                                if unique_id not in parties[leader]:
-                                    parties[leader].append(unique_id)
-                            else:
-                                parties[leader] = [unique_id]
+                            # only find party leader if unique_id is not already a party leader
+                            # this avoids some processing time and avoids errors such as when during a value update
+                            # party_leader is set as 'system_id': 0
+                            if unique_id not in parties.keys():
+                                leader_actor_type = list(
+                                    actor_data["TAGame.PRI_TA:PartyLeader"]["party_leader"]["id"][0].keys()
+                                )[0]
+                                leader = str(
+                                    actor_data["TAGame.PRI_TA:PartyLeader"]["party_leader"]["id"][0][leader_actor_type]
+                                )
+                                if leader in parties:
+                                    if unique_id not in parties[leader]:
+                                        parties[leader].append(unique_id)
+                                else:
+                                    parties[leader] = [unique_id]
                         except KeyError:
                             logger.warning('Could not get party leader for actor id: ' + str(actor_id))
                     if actor_id not in player_dicts:

--- a/carball/json_parser/player.py
+++ b/carball/json_parser/player.py
@@ -123,9 +123,13 @@ class Player:
         self.get_loadout(actor_data)
         self.party_leader = actor_data.get('TAGame.PRI_TA:PartyLeader', None)
         try:
-            if self.party_leader is not None:
+            if self.party_leader is not None and \
+                    'party_leader' in self.party_leader and \
+                    'id' in self.party_leader['party_leader']:
                 leader_actor_type = list(self.party_leader['party_leader']['id'][0].keys())[0]
                 self.party_leader = str(self.party_leader['party_leader']['id'][0][leader_actor_type])
+            else:
+                self.party_leader = None
         except KeyError:
             logger.warning('Could not set player party leader for:', self.name)
             self.party_leader = None

--- a/carball/tests/metadata/leader_test.py
+++ b/carball/tests/metadata/leader_test.py
@@ -8,9 +8,9 @@ class LeaderTest(unittest.TestCase):
     def test_0_play_station_only_party(self):
         def test(analysis: AnalysisManager):
             game = analysis.game
-            ps_party_leader = "['jamesvento98', [134, 204, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 236, 247, 155, 189, 79, 103, 54, 42]]"
-            ps_team_member_01 = "['hronaldMCdonald', [38, 76, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 74, 205, 11, 172, 194, 210, 7, 2]]"
-            ps_team_member_03 = "['DaFunnyWhiteGuy', [198, 204, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 140, 122, 205, 218, 14, 248, 148, 34]]"
+            ps_party_leader = "6083491126912347959"
+            ps_team_member_01 = "4674819165248336722"
+            ps_team_member_03 = "4911491436059516465"
             ps_team_member_02 = ps_party_leader
 
             self.assertIn(ps_party_leader, game.parties.keys())
@@ -26,11 +26,11 @@ class LeaderTest(unittest.TestCase):
 
             party_01_leader = "76561198084378722"
             party_01_member_01 = party_01_leader
-            party_01_member_02 = "1011111101011101001001001101110111011010001011100111001000010100000110010110001000010100001100100111011100010100000000000000100001011101010100101011000010111101101010110111100010101001000111110000100110010100001100011001000000110100000000000000000000000000"
+            party_01_member_02 = "2904386747031141117"
 
-            party_02_leader = "['DON_FULL_S3ND_1T', [70, 44, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 36, 178, 0, 36, 190, 50, 177, 74]]"
+            party_02_leader = "5948494783184915748"
             party_02_member_01 = party_02_leader
-            party_02_member_02 = "['freakyfitnig100', [70, 76, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 169, 39, 75, 227, 93, 88, 117, 152]]"
+            party_02_member_02 = "1850445886414578837"
 
             self.assertIn(party_01_leader, game.parties.keys())
             self.assertIn(party_01_member_01, game.parties[party_01_leader])
@@ -41,6 +41,28 @@ class LeaderTest(unittest.TestCase):
             self.assertIn(party_02_member_02, game.parties[party_02_leader])
 
         run_analysis_test_on_replay(test, get_raw_replays()["PARTY_LEADER_SYSTEM_ID_0_ERROR"])
+
+    def test_2_xbox_party(self):
+        def test(analysis: AnalysisManager):
+            game = analysis.game
+
+            party_01_leader = "76561198084378722"
+            party_01_member_01 = party_01_leader
+            party_01_member_02 = "2904386747031141117"
+
+            party_02_leader = "2535465181947426"
+            party_02_member_01 = party_02_leader
+            party_02_member_02 = "2535416417939826"
+
+            self.assertIn(party_01_leader, game.parties.keys())
+            self.assertIn(party_01_member_01, game.parties[party_01_leader])
+            self.assertIn(party_01_member_02, game.parties[party_01_leader])
+
+            self.assertIn(party_02_leader, game.parties.keys())
+            self.assertIn(party_02_member_01, game.parties[party_02_leader])
+            self.assertIn(party_02_member_02, game.parties[party_02_leader])
+
+        run_analysis_test_on_replay(test, get_raw_replays()["XBOX_PARTY"])
 
 
 if __name__ == '__main__':

--- a/carball/tests/metadata/leader_test.py
+++ b/carball/tests/metadata/leader_test.py
@@ -1,0 +1,47 @@
+import unittest
+from carball.analysis.analysis_manager import AnalysisManager
+from carball.tests.utils import run_analysis_test_on_replay, get_raw_replays
+
+
+class LeaderTest(unittest.TestCase):
+
+    def test_0_play_station_only_party(self):
+        def test(analysis: AnalysisManager):
+            game = analysis.game
+            ps_party_leader = "['jamesvento98', [134, 204, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 236, 247, 155, 189, 79, 103, 54, 42]]"
+            ps_team_member_01 = "['hronaldMCdonald', [38, 76, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 74, 205, 11, 172, 194, 210, 7, 2]]"
+            ps_team_member_03 = "['DaFunnyWhiteGuy', [198, 204, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 140, 122, 205, 218, 14, 248, 148, 34]]"
+            ps_team_member_02 = ps_party_leader
+
+            self.assertIn(ps_party_leader, game.parties.keys())
+            self.assertIn(ps_team_member_01, game.parties[ps_party_leader])
+            self.assertIn(ps_team_member_02, game.parties[ps_party_leader])
+            self.assertIn(ps_team_member_03, game.parties[ps_party_leader])
+
+        run_analysis_test_on_replay(test, get_raw_replays()["PLAY_STATION_ONLY_PARTY"])
+
+    def test_1_party_leader_system_id_0(self):
+        def test(analysis: AnalysisManager):
+            game = analysis.game
+
+            party_01_leader = "76561198084378722"
+            party_01_member_01 = party_01_leader
+            party_01_member_02 = "1011111101011101001001001101110111011010001011100111001000010100000110010110001000010100001100100111011100010100000000000000100001011101010100101011000010111101101010110111100010101001000111110000100110010100001100011001000000110100000000000000000000000000"
+
+            party_02_leader = "['DON_FULL_S3ND_1T', [70, 44, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 36, 178, 0, 36, 190, 50, 177, 74]]"
+            party_02_member_01 = party_02_leader
+            party_02_member_02 = "['freakyfitnig100', [70, 76, 174, 206, 14, 206, 44, 0, 128, 0, 0, 0, 0, 0, 0, 0, 169, 39, 75, 227, 93, 88, 117, 152]]"
+
+            self.assertIn(party_01_leader, game.parties.keys())
+            self.assertIn(party_01_member_01, game.parties[party_01_leader])
+            self.assertIn(party_01_member_02, game.parties[party_01_leader])
+
+            self.assertIn(party_02_leader, game.parties.keys())
+            self.assertIn(party_02_member_01, game.parties[party_02_leader])
+            self.assertIn(party_02_member_02, game.parties[party_02_leader])
+
+        run_analysis_test_on_replay(test, get_raw_replays()["PARTY_LEADER_SYSTEM_ID_0_ERROR"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -161,6 +161,13 @@ def get_raw_replays():
         "DEFAULT_3_ON_3_AROUND_58_HITS": [
             "https://cdn.discordapp.com/attachments/493849514680254468/496820586811621387/DEFAULT_3_ON_3_AROUND_58_HITS.replay"],
 
+        # parties
+        "PLAY_STATION_ONLY_PARTY": [
+            'https://cdn.discordapp.com/attachments/493849514680254468/563457368193761301/PLAY_STATION_ONLY_PARTY.replay'],
+
+        "XBOX_PARTY": [
+            "https://cdn.discordapp.com/attachments/493849514680254468/563831620222844928/XBOX_PARTY.replay"
+        ],
         # error cases
         "UNICODE_ERROR": [
             "https://cdn.discordapp.com/attachments/493849514680254468/493880540802449462/UnicodeEncodeError.replay"],
@@ -168,8 +175,6 @@ def get_raw_replays():
             "https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay"],
         "PARTY_LEADER_SYSTEM_ID_0_ERROR": [
             'https://cdn.discordapp.com/attachments/493849514680254468/563036945635082260/PARTY_LEADER_SYSTEM_ID_0.replay'],
-        "PLAY_STATION_ONLY_PARTY": [
-            'https://cdn.discordapp.com/attachments/493849514680254468/563457368193761301/PLAY_STATION_ONLY_PARTY.replay'],
     }
 
 
@@ -196,7 +201,8 @@ def get_specific_replays():
         # HITS
         "HITS": raw_map["4_SHOTS"] + raw_map["KICKOFF_3_HITS"] + raw_map["12_BOOST_PAD_45_USED"] +
                 raw_map["MID_AIR_PASS"] + raw_map["HIGH_AIR_PASS"] + raw_map["GROUND_PASS"] +
-                raw_map["1_NORMAL_SAVE"] + raw_map["1_EPIC_SAVE"] + raw_map["1_AERIAL"] + raw_map["DEFAULT_3_ON_3_AROUND_58_HITS"],
+                raw_map["1_NORMAL_SAVE"] + raw_map["1_EPIC_SAVE"] + raw_map["1_AERIAL"] +
+                raw_map["DEFAULT_3_ON_3_AROUND_58_HITS"],
         # + raw_map["PINCH_GROUND"],  TODO: Fix pinches to create 2 hits 1 for each person on same frame
         "SHOTS": raw_map["4_SHOTS"] + raw_map["12_BOOST_PAD_45_USED"] +
                  raw_map["1_EPIC_SAVE"] + raw_map["1_NORMAL_SAVE"],

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -168,6 +168,8 @@ def get_raw_replays():
             "https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay"],
         "PARTY_LEADER_SYSTEM_ID_0_ERROR": [
             'https://cdn.discordapp.com/attachments/493849514680254468/563036945635082260/PARTY_LEADER_SYSTEM_ID_0.replay'],
+        "PLAY_STATION_ONLY_PARTY": [
+            'https://cdn.discordapp.com/attachments/493849514680254468/563457368193761301/PLAY_STATION_ONLY_PARTY.replay'],
     }
 
 

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -84,7 +84,8 @@ def get_complex_replay_list():
         'https://cdn.discordapp.com/attachments/493849514680254468/497149910999891969/NEGATIVE_WASTED_COLLECTION.replay',
         'https://cdn.discordapp.com/attachments/493849514680254468/497191273619259393/WASTED_BOOST_WHILE_SUPER_SONIC.replay',
         'https://cdn.discordapp.com/attachments/493849514680254468/501630263881760798/OCE_RLCS_7_CARS.replay',
-        'https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay'
+        'https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay',
+        'https://cdn.discordapp.com/attachments/493849514680254468/563036945635082260/PARTY_LEADER_SYSTEM_ID_0.replay',
     ]
 
 
@@ -165,6 +166,8 @@ def get_raw_replays():
             "https://cdn.discordapp.com/attachments/493849514680254468/493880540802449462/UnicodeEncodeError.replay"],
         "CROSSPLATFORM_PARTY_LEADER_ERROR": [
             "https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay"],
+        "PARTY_LEADER_SYSTEM_ID_0_ERROR": [
+            'https://cdn.discordapp.com/attachments/493849514680254468/563036945635082260/PARTY_LEADER_SYSTEM_ID_0.replay'],
     }
 
 
@@ -220,6 +223,6 @@ def get_specific_answers():
 def assertNearlyEqual(self, a, b, percent=2.0, msg=None):
     if abs(a - b) > abs(percent / 100.0 * min(abs(a), abs(b))):
         if msg is None:
-            self.fail("The given numbers %s and %s are not within %s percent of each other."%(a, b, percent))
+            self.fail("The given numbers %s and %s are not within %s percent of each other." % (a, b, percent))
         else:
             self.fail(msg)


### PR DESCRIPTION
This PR includes some simple fixes for the following:
  * party_leader is only set if leader_actor_type can be resolved
  * avoid continuously setting party leader, if it already exists.  This also mitigate errors where an update such as:
```
{
  "actor_id": {
    "limit": 2047,
    "value": 13
  },
  "value": {
    "updated": [
      {
        "id": {
          "limit": 104,
          "value": 53
        },
        "name": "TAGame.PRI_TA:PartyLeader",
        "value": {
          "party_leader": {
            "system_id": 0
          }
        }
      }
    ]
  }
}

```

where `party_leader` is `"system_id": 0` , which would cause `Could not get party leader for actor id`, even though it has already been resolved previously.
  * Add relevant replay and tests.
