### PR TITLE
Rumble stats

### DIFF
--- a/api/metadata/game_metadata.proto
+++ b/api/metadata/game_metadata.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 
 import "api/player_id.proto";
+import "api/stats/rumble.proto";
 
 package api.metadata;
 
@@ -37,8 +38,7 @@ message GameScore {
 message Goal {
     optional int32 frame_number = 1;
     optional api.PlayerId player_id = 2;
-    optional bool pre_rumble_items = 3;
-    optional string used_rumble_item = 4;
+    optional api.stats.RumbleGoalInfo rumble_info = 3;
 }
 
 message Demo {

--- a/api/metadata/game_metadata.proto
+++ b/api/metadata/game_metadata.proto
@@ -38,6 +38,7 @@ message Goal {
     optional int32 frame_number = 1;
     optional api.PlayerId player_id = 2;
     optional bool pre_rumble_items = 3;
+    optional string used_rumble_item = 4;
 }
 
 message Demo {

--- a/api/metadata/game_metadata.proto
+++ b/api/metadata/game_metadata.proto
@@ -37,6 +37,7 @@ message GameScore {
 message Goal {
     optional int32 frame_number = 1;
     optional api.PlayerId player_id = 2;
+    optional bool pre_rumble_items = 3;
 }
 
 message Demo {

--- a/api/metadata/game_metadata.proto
+++ b/api/metadata/game_metadata.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 
 import "api/player_id.proto";
-import "api/stats/rumble.proto";
+import "api/stats/extra_mode_stats.proto";
 
 package api.metadata;
 
@@ -38,7 +38,7 @@ message GameScore {
 message Goal {
     optional int32 frame_number = 1;
     optional api.PlayerId player_id = 2;
-    optional api.stats.RumbleGoalInfo rumble_info = 3;
+    optional api.stats.ExtraModeGoalInfo extra_mode_info = 3;
 }
 
 message Demo {

--- a/api/stats/events.proto
+++ b/api/stats/events.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 
 import "api/player_id.proto";
-import "api/stats/rumble.proto";
+import "api/stats/extra_mode_stats.proto";
 
 package api.stats;
 

--- a/api/stats/events.proto
+++ b/api/stats/events.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 
 import "api/player_id.proto";
+import "api/stats/rumble.proto";
 
 package api.stats;
 
@@ -83,7 +84,7 @@ message Kickoff {
 message RumbleItemEvent {
     optional int32 frame_number_get = 1;
     optional int32 frame_number_use = 2 [default = -1];
-    optional string item = 3;
+    optional api.stats.PowerUp item = 3;
     optional api.PlayerId player_id = 4;
     optional api.PlayerId victim_id = 5; // TODO Not implemented, including ball target as things like plunger can fail
 }

--- a/api/stats/events.proto
+++ b/api/stats/events.proto
@@ -82,7 +82,7 @@ message Kickoff {
 
 message RumbleItemEvent {
     optional int32 frame_number_get = 1;
-    optional int32 frame_number_use = 2;
+    optional int32 frame_number_use = 2 [default = -1];
     optional string item = 3;
     optional api.PlayerId player_id = 4;
     optional api.PlayerId victim_id = 5; // TODO Not implemented, including ball target as things like plunger can fail

--- a/api/stats/events.proto
+++ b/api/stats/events.proto
@@ -79,3 +79,11 @@ message Kickoff {
     optional int32 start_frame_number = 1;
     optional int32 end_frame_number = 2;
 }
+
+message RumbleItemEvent {
+    optional int32 frame_number_get = 1;
+    optional int32 frame_number_use = 2;
+    optional string item = 3;
+    optional api.PlayerId player_id = 4;
+    optional api.PlayerId victim_id = 5; // TODO Not implemented, including ball target as things like plunger can fail
+}

--- a/api/stats/extra_mode_stats.proto
+++ b/api/stats/extra_mode_stats.proto
@@ -30,7 +30,7 @@ message RumbleItemsUsage {
     optional float average_hold = 4;
 }
 
-message RumbleGoalInfo {
+message ExtraModeGoalInfo {
     optional bool pre_items = 1;
     optional bool scored_with_item = 2;
     optional PowerUp used_item = 3;

--- a/api/stats/game_stats.proto
+++ b/api/stats/game_stats.proto
@@ -11,4 +11,5 @@ message GameStats {
     repeated api.stats.Bump bumps = 3;
     optional api.stats.BallStats ball_stats = 4;
     repeated api.stats.Kickoff kickoffs = 5;
+    repeated api.stats.RumbleItemEvent rumble_items = 6;
 }

--- a/api/stats/player_stats.proto
+++ b/api/stats/player_stats.proto
@@ -64,7 +64,7 @@ message PlayerStats {
     optional api.stats.Speed speed = 9;
     optional RelativePositioning relative_positioning = 10;
     optional api.stats.PerPossessionStats per_possession_stats = 11;
-    optional api.stats.RumbleItemUsage rumble_item_usage = 11;
+    optional api.stats.RumbleItemUsage rumble_item_usage = 12;
 }
 
 message Controller {

--- a/api/stats/player_stats.proto
+++ b/api/stats/player_stats.proto
@@ -64,7 +64,7 @@ message PlayerStats {
     optional api.stats.Speed speed = 9;
     optional RelativePositioning relative_positioning = 10;
     optional api.stats.PerPossessionStats per_possession_stats = 11;
-    optional api.stats.RumbleItemUsage rumble_item_usage = 12;
+    optional api.stats.RumbleItems rumble_items = 12;
 }
 
 message Controller {

--- a/api/stats/player_stats.proto
+++ b/api/stats/player_stats.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 import "api/stats/stats.proto";
 import "api/stats/events.proto";
+import "api/stats/rumble.proto";
 
 package api.stats;
 
@@ -61,6 +62,7 @@ message PlayerStats {
     optional Controller controller = 8;
     optional api.stats.Speed speed = 9;
     optional RelativePositioning relative_positioning = 10;
+    optional api.stats.RumbleItemUsage rumble_item_usage = 11;
 }
 
 message Controller {

--- a/api/stats/player_stats.proto
+++ b/api/stats/player_stats.proto
@@ -64,7 +64,7 @@ message PlayerStats {
     optional api.stats.Speed speed = 9;
     optional RelativePositioning relative_positioning = 10;
     optional api.stats.PerPossessionStats per_possession_stats = 11;
-    optional api.stats.RumbleItems rumble_items = 12;
+    optional api.stats.RumbleStats rumble_stats = 12;
 }
 
 message Controller {

--- a/api/stats/player_stats.proto
+++ b/api/stats/player_stats.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 import "api/stats/stats.proto";
 import "api/stats/events.proto";
 import "api/stats/per_possession_stats.proto";
-import "api/stats/rumble.proto";
+import "api/stats/extra_mode_stats.proto";
 
 package api.stats;
 

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -2,16 +2,22 @@ syntax = "proto2";
 
 package api.stats;
 
-message RumbleItemUsage {
-    optional int32 ball_freeze = 1;
-    optional int32 ball_grappling_hook = 2;
-    optional int32 ball_lasso = 3;
-    optional int32 ball_spring = 4;
-    optional int32 ball_velcro = 5;
-    optional int32 boost_override = 6;
-    optional int32 car_spring = 7;
-    optional int32 gravity_well = 8;
-    optional int32 strong_hit = 9;
-    optional int32 swapper = 10;
-    optional int32 tornado = 11;
+message RumbleItems {
+    optional RumbleItemsUsage ball_freeze = 1;
+    optional RumbleItemsUsage ball_grappling_hook = 2;
+    optional RumbleItemsUsage ball_lasso = 3;
+    optional RumbleItemsUsage ball_spring = 4;
+    optional RumbleItemsUsage ball_velcro = 5;
+    optional RumbleItemsUsage boost_override = 6;
+    optional RumbleItemsUsage car_spring = 7;
+    optional RumbleItemsUsage gravity_well = 8;
+    optional RumbleItemsUsage strong_hit = 9;
+    optional RumbleItemsUsage swapper = 10;
+    optional RumbleItemsUsage tornado = 11;
+}
+
+message RumbleItemsUsage {
+    optional int32 used = 1;
+    optional int32 unused = 2;
+    optional float average_hold = 3;
 }

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -31,6 +31,6 @@ message RumbleItemsUsage {
 }
 
 message RumbleGoalInfo {
-    optional bool pre_item = 1;
+    optional bool pre_items = 1;
     optional PowerUp used_item = 2;
 }

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -2,27 +2,28 @@ syntax = "proto2";
 
 package api.stats;
 
+enum PowerUp {
+    BALL_FREEZE = 1;
+    BALL_GRAPPLING_HOOK = 2;
+    BALL_LASSO = 3;
+    BALL_SPRING = 4;
+    BALL_VELCRO = 5;
+    BOOST_OVERRIDE = 6;
+    CAR_SPRING = 7;
+    GRAVITY_WELL = 8;
+    STRONG_HIT = 9;
+    SWAPPER = 10;
+    TORNADO = 11;
+}
+
 message RumbleStats {
-    optional RumbleItems rumble_items = 1;
+    repeated RumbleItemsUsage rumble_items = 1;
     optional int32 pre_item_goals = 2;
 }
 
-message RumbleItems {
-    optional RumbleItemsUsage ball_freeze = 1;
-    optional RumbleItemsUsage ball_grappling_hook = 2;
-    optional RumbleItemsUsage ball_lasso = 3;
-    optional RumbleItemsUsage ball_spring = 4;
-    optional RumbleItemsUsage ball_velcro = 5;
-    optional RumbleItemsUsage boost_override = 6;
-    optional RumbleItemsUsage car_spring = 7;
-    optional RumbleItemsUsage gravity_well = 8;
-    optional RumbleItemsUsage strong_hit = 9;
-    optional RumbleItemsUsage swapper = 10;
-    optional RumbleItemsUsage tornado = 11;
-}
-
 message RumbleItemsUsage {
-    optional int32 used = 1;
-    optional int32 unused = 2;
-    optional float average_hold = 3;
+    optional PowerUp item = 1;
+    optional int32 used = 2;
+    optional int32 unused = 3;
+    optional float average_hold = 4;
 }

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+package api.stats;
+
+message RumbleItemUsage {
+    optional int32 ball_freeze = 1;
+    optional int32 ball_grappling_hook = 2;
+    optional int32 ball_lasso = 3;
+    optional int32 ball_spring = 4;
+    optional int32 ball_velcro = 5;
+    optional int32 boost_override = 6;
+    optional int32 car_spring = 7;
+    optional int32 gravity_well = 8;
+    optional int32 strong_hit = 9;
+    optional int32 swapper = 10;
+    optional int32 tornado = 11;
+}

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -32,5 +32,6 @@ message RumbleItemsUsage {
 
 message RumbleGoalInfo {
     optional bool pre_items = 1;
-    optional PowerUp used_item = 2;
+    optional bool scored_with_item = 2;
+    optional PowerUp used_item = 3;
 }

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -29,3 +29,8 @@ message RumbleItemsUsage {
     optional int32 unused = 3;
     optional float average_hold = 4;
 }
+
+message RumbleGoalInfo {
+    optional bool pre_item = 1;
+    optional PowerUp used_item = 2;
+}

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -2,6 +2,11 @@ syntax = "proto2";
 
 package api.stats;
 
+message RumbleStats {
+    optional RumbleItems rumble_items = 1;
+    optional int32 pre_item_goals = 2;
+}
+
 message RumbleItems {
     optional RumbleItemsUsage ball_freeze = 1;
     optional RumbleItemsUsage ball_grappling_hook = 2;

--- a/api/stats/rumble.proto
+++ b/api/stats/rumble.proto
@@ -3,9 +3,11 @@ syntax = "proto2";
 package api.stats;
 
 enum PowerUp {
+    option allow_alias = true;
     BALL_FREEZE = 1;
     BALL_GRAPPLING_HOOK = 2;
     BALL_LASSO = 3;
+    BATARANG = 3;
     BALL_SPRING = 4;
     BALL_VELCRO = 5;
     BOOST_OVERRIDE = 6;

--- a/api/stats/team_stats.proto
+++ b/api/stats/team_stats.proto
@@ -23,5 +23,5 @@ message TeamStats {
     optional api.stats.HitCounts hit_counts = 2;
     optional CenterOfMass center_of_mass = 3;
     optional PerPossessionStats per_possession_stats = 4;
-    optional api.stats.RumbleItemUsage rumble_item_usage = 5;
+    optional api.stats.RumbleItems rumble_items = 5;
 }

--- a/api/stats/team_stats.proto
+++ b/api/stats/team_stats.proto
@@ -23,5 +23,5 @@ message TeamStats {
     optional api.stats.HitCounts hit_counts = 2;
     optional CenterOfMass center_of_mass = 3;
     optional PerPossessionStats per_possession_stats = 4;
-    optional api.stats.RumbleItemUsage rumble_item_usage = 11;
+    optional api.stats.RumbleItemUsage rumble_item_usage = 5;
 }

--- a/api/stats/team_stats.proto
+++ b/api/stats/team_stats.proto
@@ -23,5 +23,5 @@ message TeamStats {
     optional api.stats.HitCounts hit_counts = 2;
     optional CenterOfMass center_of_mass = 3;
     optional PerPossessionStats per_possession_stats = 4;
-    optional api.stats.RumbleItems rumble_items = 5;
+    optional api.stats.RumbleStats rumble_stats = 5;
 }

--- a/api/stats/team_stats.proto
+++ b/api/stats/team_stats.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 import "api/stats/stats.proto";
 import "api/stats/per_possession_stats.proto";
-import "api/stats/rumble.proto";
+import "api/stats/extra_mode_stats.proto";
 
 package api.stats;
 

--- a/api/stats/team_stats.proto
+++ b/api/stats/team_stats.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 
 import "api/stats/stats.proto";
+import "api/stats/rumble.proto";
 
 package api.stats;
 
@@ -20,4 +21,5 @@ message TeamStats {
     optional api.stats.Possession possession = 1;
     optional api.stats.HitCounts hit_counts = 2;
     optional CenterOfMass center_of_mass = 3;
+    optional api.stats.RumbleItemUsage rumble_item_usage = 11;
 }

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -32,9 +32,9 @@ class PreRumbleGoals(BaseStat):
             if next_get_frame > goal.frame_number or next_get_frame == -1:
                 # goal before rumble items
                 pre_power_up_goals[player_map[goal.player_id.id].is_orange] += 1
-                goal.rumble_info.pre_items = True
+                goal.extra_mode_info.pre_items = True
             else:
-                goal.rumble_info.pre_items = False
+                goal.extra_mode_info.pre_items = False
 
         team_stat_list[0].rumble_stats.pre_item_goals = pre_power_up_goals[0]
         team_stat_list[1].rumble_stats.pre_item_goals = pre_power_up_goals[1]
@@ -60,8 +60,8 @@ class ItemGoals(BaseStat):
             player_df = player_df.loc[start_frame:goal.frame_number]
 
             if player_df['power_up_active'].any():
-                goal.rumble_info.scored_with_item = True
-                goal.rumble_info.used_item = PowerUp.Value(player_df.loc[player_df['power_up_active'] == True]
+                goal.extra_mode_info.scored_with_item = True
+                goal.extra_mode_info.used_item = PowerUp.Value(player_df.loc[player_df['power_up_active'] == True]
                                                            .iloc[0]['power_up'].upper())
             else:
-                goal.rumble_info.scored_with_item = False
+                goal.extra_mode_info.scored_with_item = False

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -1,0 +1,36 @@
+from typing import Dict
+
+import pandas as pd
+
+from carball.analysis.stats.stats import BaseStat
+from carball.generated.api import game_pb2
+from carball.generated.api.player_pb2 import Player
+from carball.generated.api.stats.team_stats_pb2 import TeamStats
+from carball.json_parser.game import Game
+from carball.generated.api.metadata.game_metadata_pb2 import RANKED_RUMBLE, UNRANKED_RUMBLE
+
+
+class PreRumbleGoals(BaseStat):
+
+    def calculate_team_stat(self, team_stat_list: Dict[int, TeamStats], game: Game, proto_game: game_pb2.Game,
+                            player_map: Dict[str, Player], data_frame: pd.DataFrame):
+        if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
+            return
+
+        pre_power_up_goals = (0, 0)
+
+        item_get_frames = sorted(set(map(lambda event: event.frame_number_get, proto_game.game_stats.rumble_items)))
+
+        for goal in game.goals:
+            # kick off frame before the goal
+            kickoff_frame = next(frame for frame in reversed(game.kickoff_frames) if frame < goal.frame_number)
+
+            # first item get frame after kick off
+            next_get_frame = next(frame for frame in item_get_frames if frame > kickoff_frame)
+
+            if next_get_frame > goal.frame_number:
+                # goal before rumble items
+                pre_power_up_goals[goal.player_team] += 1
+
+        team_stat_list[0].rumble_stats.pre_item_goals = pre_power_up_goals[0]
+        team_stat_list[1].rumble_stats.pre_item_goals = pre_power_up_goals[1]

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -18,7 +18,7 @@ class PreRumbleGoals(BaseStat):
         if not is_rumble_enabled(game):
             return
 
-        pre_power_up_goals = (0, 0)
+        pre_power_up_goals = [0, 0]
 
         item_get_frames = sorted(set(map(lambda event: event.frame_number_get, proto_game.game_stats.rumble_items)))
 
@@ -31,8 +31,10 @@ class PreRumbleGoals(BaseStat):
 
             if next_get_frame > goal.frame_number:
                 # goal before rumble items
-                pre_power_up_goals[goal.player_team] += 1
+                pre_power_up_goals[player_map[goal.player_id.id].is_orange] += 1
                 goal.rumble_info.pre_items = True
+            else:
+                goal.rumble_info.pre_items = False
 
         team_stat_list[0].rumble_stats.pre_item_goals = pre_power_up_goals[0]
         team_stat_list[1].rumble_stats.pre_item_goals = pre_power_up_goals[1]

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -60,5 +60,8 @@ class ItemGoals(BaseStat):
             player_df = player_df.loc[start_frame:goal.frame_number]
 
             if player_df['power_up_active'].any():
+                goal.rumble_info.scored_with_item = True
                 goal.rumble_info.used_item = PowerUp.Value(player_df.loc[player_df['power_up_active'] == True]
                                                            .iloc[0]['power_up'].upper())
+            else:
+                goal.rumble_info.scored_with_item = False

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -27,9 +27,9 @@ class PreRumbleGoals(BaseStat):
             kickoff_frame = next(frame for frame in reversed(game.kickoff_frames) if frame < goal.frame_number)
 
             # first item get frame after kick off
-            next_get_frame = next(frame for frame in item_get_frames if frame > kickoff_frame)
+            next_get_frame = next((frame for frame in item_get_frames if frame > kickoff_frame), -1)
 
-            if next_get_frame > goal.frame_number:
+            if next_get_frame > goal.frame_number or next_get_frame == -1:
                 # goal before rumble items
                 pre_power_up_goals[player_map[goal.player_id.id].is_orange] += 1
                 goal.rumble_info.pre_items = True

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -21,7 +21,7 @@ class PreRumbleGoals(BaseStat):
 
         item_get_frames = sorted(set(map(lambda event: event.frame_number_get, proto_game.game_stats.rumble_items)))
 
-        for goal in game.goals:
+        for goal in proto_game.game_metadata.goals:
             # kick off frame before the goal
             kickoff_frame = next(frame for frame in reversed(game.kickoff_frames) if frame < goal.frame_number)
 
@@ -31,6 +31,7 @@ class PreRumbleGoals(BaseStat):
             if next_get_frame > goal.frame_number:
                 # goal before rumble items
                 pre_power_up_goals[goal.player_team] += 1
+                goal.pre_rumble_items = True
 
         team_stat_list[0].rumble_stats.pre_item_goals = pre_power_up_goals[0]
         team_stat_list[1].rumble_stats.pre_item_goals = pre_power_up_goals[1]

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -7,14 +7,14 @@ from carball.generated.api import game_pb2
 from carball.generated.api.player_pb2 import Player
 from carball.generated.api.stats.team_stats_pb2 import TeamStats
 from carball.json_parser.game import Game
-from carball.generated.api.metadata.game_metadata_pb2 import RANKED_RUMBLE, UNRANKED_RUMBLE
+from carball.analysis.stats.rumble.rumble import is_rumble_enabled
 
 
 class PreRumbleGoals(BaseStat):
 
     def calculate_team_stat(self, team_stat_list: Dict[int, TeamStats], game: Game, proto_game: game_pb2.Game,
                             player_map: Dict[str, Player], data_frame: pd.DataFrame):
-        if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
+        if not is_rumble_enabled(game):
             return
 
         pre_power_up_goals = (0, 0)

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -6,7 +6,7 @@ from carball.analysis.stats.stats import BaseStat
 from carball.generated.api import game_pb2
 from carball.generated.api.player_pb2 import Player
 from carball.generated.api.stats.team_stats_pb2 import TeamStats
-from carball.generated.api.stats.rumble_pb2 import PowerUp
+from carball.generated.api.stats.extra_mode_stats_pb2 import PowerUp
 from carball.json_parser.game import Game
 from carball.analysis.stats.rumble.rumble import is_rumble_enabled
 

--- a/carball/analysis/stats/rumble/goals.py
+++ b/carball/analysis/stats/rumble/goals.py
@@ -6,6 +6,7 @@ from carball.analysis.stats.stats import BaseStat
 from carball.generated.api import game_pb2
 from carball.generated.api.player_pb2 import Player
 from carball.generated.api.stats.team_stats_pb2 import TeamStats
+from carball.generated.api.stats.rumble_pb2 import PowerUp
 from carball.json_parser.game import Game
 from carball.analysis.stats.rumble.rumble import is_rumble_enabled
 
@@ -31,7 +32,7 @@ class PreRumbleGoals(BaseStat):
             if next_get_frame > goal.frame_number:
                 # goal before rumble items
                 pre_power_up_goals[goal.player_team] += 1
-                goal.pre_rumble_items = True
+                goal.rumble_info.pre_items = True
 
         team_stat_list[0].rumble_stats.pre_item_goals = pre_power_up_goals[0]
         team_stat_list[1].rumble_stats.pre_item_goals = pre_power_up_goals[1]
@@ -57,4 +58,5 @@ class ItemGoals(BaseStat):
             player_df = player_df.loc[start_frame:goal.frame_number]
 
             if player_df['power_up_active'].any():
-                goal.used_rumble_item = player_df.loc[player_df['power_up_active'] == True].iloc[0]['power_up']
+                goal.rumble_info.used_item = PowerUp.Value(player_df.loc[player_df['power_up_active'] == True]
+                                                           .iloc[0]['power_up'].upper())

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -53,7 +53,8 @@ def is_rumble_enabled(game: Game) -> bool:
     :return: True if rumble
     """
     return game.game_info.playlist in [RANKED_RUMBLE, UNRANKED_RUMBLE] or \
-           game.game_info.rumble_mutator.startswith('Archetypes.Mutators.SubRules.ItemsMode')
+           (game.game_info.rumble_mutator is not None and
+            game.game_info.rumble_mutator.startswith('Archetypes.Mutators.SubRules.ItemsMode'))
 
 
 def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rumble_item_events) \

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -72,10 +72,15 @@ def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rum
         df = df[['time_till_power_up', 'power_up', 'power_up_active']]
 
         ranges = [(game.kickoff_frames[i], game.kickoff_frames[i + 1]) for i in range(len(game.kickoff_frames) - 1)]
+        ranges.append((game.kickoff_frames[-1], df.index[-1]))
         data_frames = map(lambda x: df.loc[x[0]:x[1] - 1], ranges)
         data_frames = map(_squash_power_up_df, data_frames)
 
         for data_frame in data_frames:
+
+            if len(data_frame) == 0:
+                # goal before items
+                continue
 
             prev_row = data_frame.iloc[0]
             proto_current_item = None

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -1,0 +1,148 @@
+import math
+from typing import Dict
+
+import pandas as pd
+
+from carball.generated.api import game_pb2
+from carball.generated.api.player_pb2 import Player
+from carball.generated.api.stats.player_stats_pb2 import PlayerStats
+from carball.generated.api.stats.team_stats_pb2 import TeamStats
+from carball.json_parser.game import Game
+from carball.analysis.stats.stats import BaseStat
+from carball.generated.api.metadata.game_metadata_pb2 import RANKED_RUMBLE, UNRANKED_RUMBLE
+
+_BASE = {
+    'ball_freeze': 0,
+    'ball_grappling_hook': 0,
+    'ball_lasso': 0,
+    'ball_spring': 0,
+    'ball_velcro': 0,
+    'batarang': 0,
+    'boost_override': 0,
+    'car_spring': 0,
+    'gravity_well': 0,
+    'strong_hit': 0,
+    'swapper': 0,
+    'tornado': 0
+}
+
+
+class RumbleItemStat(BaseStat):
+
+    def calculate_player_stat(self, player_stat_map: Dict[str, PlayerStats], game: Game, proto_game: game_pb2.Game,
+                              player_map: Dict[str, Player], data_frame: pd.DataFrame):
+        if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
+            return
+
+        for player_key, stats in player_stat_map.items():
+            player_name = player_map[player_key].name
+            player_data_frame = data_frame[player_name]
+
+            item_stats = _get_power_up_stats(player_data_frame, data_frame['ball'])
+
+            rumble_proto = stats.rumble_item_usage
+
+            rumble_proto.ball_freeze = item_stats['ball_freeze']
+            rumble_proto.ball_grappling_hook = item_stats['ball_grappling_hook']
+            rumble_proto.ball_lasso = item_stats['ball_lasso']
+            rumble_proto.ball_spring = item_stats['ball_spring']
+            rumble_proto.ball_velcro = item_stats['ball_velcro']
+            rumble_proto.boost_override = item_stats['boost_override']
+            rumble_proto.car_spring = item_stats['car_spring']
+            rumble_proto.gravity_well = item_stats['gravity_well']
+            rumble_proto.strong_hit = item_stats['strong_hit']
+            rumble_proto.swapper = item_stats['swapper']
+            rumble_proto.tornado = item_stats['tornado']
+
+    def calculate_team_stat(self, team_stat_list: Dict[int, TeamStats], game: Game, proto_game: game_pb2.Game,
+                            player_map: Dict[str, Player], data_frame: pd.DataFrame):
+        if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
+            return
+
+        for key, team in team_stat_list.items():
+            rumble_proto = team.rumble_item_usage
+
+            rumble_proto.ball_freeze = 0
+            rumble_proto.ball_grappling_hook = 0
+            rumble_proto.ball_lasso = 0
+            rumble_proto.ball_spring = 0
+            rumble_proto.ball_velcro = 0
+            rumble_proto.boost_override = 0
+            rumble_proto.car_spring = 0
+            rumble_proto.gravity_well = 0
+            rumble_proto.strong_hit = 0
+            rumble_proto.swapper = 0
+            rumble_proto.tornado = 0
+
+        for key, player in player_map.items():
+            rumble_proto = team_stat_list[player.is_orange].rumble_item_usage
+            player_rumble_stats = player.stats.rumble_item_usage
+
+            rumble_proto.ball_freeze += player_rumble_stats.ball_freeze
+            rumble_proto.ball_grappling_hook += player_rumble_stats.ball_grappling_hook
+            rumble_proto.ball_lasso += player_rumble_stats.ball_lasso
+            rumble_proto.ball_spring += player_rumble_stats.ball_spring
+            rumble_proto.ball_velcro += player_rumble_stats.ball_velcro
+            rumble_proto.boost_override += player_rumble_stats.boost_override
+            rumble_proto.car_spring += player_rumble_stats.car_spring
+            rumble_proto.gravity_well += player_rumble_stats.gravity_well
+            rumble_proto.strong_hit += player_rumble_stats.strong_hit
+            rumble_proto.swapper += player_rumble_stats.swapper
+            rumble_proto.tornado += player_rumble_stats.tornado
+
+
+def _get_power_up_stats(df: pd.DataFrame, ball_df: pd.DataFrame):
+    all_items = dict(_BASE)
+
+    if 'power_up_active' in df and 'power_up' in df:
+        df = df[['power_up', 'power_up_active']]
+        df = _squash_power_up_df(df, ball_df)
+
+        used_items = df.groupby('power_up')['power_up'].size().to_dict()
+
+        all_items.update(used_items)
+
+    all_items['ball_lasso'] += all_items.pop('batarang')
+
+    return all_items
+
+
+def _squash_power_up_df(df: pd.DataFrame, ball_df: pd.DataFrame):
+    mask = []
+    prev_false = False
+    prev_power_up = None
+
+    for i, row in df.iterrows():
+        if math.isnan(row['power_up_active']):
+            if prev_false and prev_power_up == 'ball_freeze':
+                # When a spiked ball is frozen, there is not 'ball_freeze,True' row, it just gets deleted immediately
+                # Could also happen when the freeze is immediately broken
+                # in theory this should not happen with other power ups
+                ball_reset = _check_ball_reset(ball_df, i)
+                if not ball_reset:
+                    mask[-1] = True
+
+            mask.append(False)
+            prev_false = False
+        elif not row['power_up_active']:
+            mask.append(False)
+            prev_false = True
+            prev_power_up = row['power_up']
+        else:
+            mask.append(prev_false)
+            prev_false = False
+            prev_power_up = row['power_up']
+
+    return df[mask]
+
+
+def _check_ball_reset(ball_df: pd.DataFrame, index: int):
+    for i in range(index, index + 10):
+        if i >= len(ball_df):
+            return True
+
+        row = ball_df.loc[i]
+        if math.isnan(row['pos_x']) or row['pos_x'] == 0.0 and row['pos_y'] == 0.0:
+            return True
+
+    return False

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -8,7 +8,7 @@ from carball.generated.api.player_pb2 import Player
 from carball.generated.api.stats.player_stats_pb2 import PlayerStats
 from carball.generated.api.stats.team_stats_pb2 import TeamStats
 from carball.generated.api.stats.events_pb2 import RumbleItemEvent
-from carball.generated.api.stats.rumble_pb2 import PowerUp, RumbleStats
+from carball.generated.api.stats.extra_mode_stats_pb2 import PowerUp, RumbleStats
 from carball.json_parser.game import Game
 from carball.analysis.stats.stats import BaseStat
 from carball.generated.api.metadata.game_metadata_pb2 import RANKED_RUMBLE, UNRANKED_RUMBLE

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -132,6 +132,10 @@ def _squash_power_up_df(df: pd.DataFrame):
     a = a.loc[(a.shift(-1).isnull() ^ a.isnull()) | (a.shift(1).isnull() ^ a.isnull()) | ~a.isnull()]
     a = a.loc[(a.shift(1) != a) | (a.shift(-1) != a)]
 
+    # Drop any false values that come after true values
+    while len(a.loc[(a.shift(1) == True) & (a == False)]) > 0:
+        a = a.loc[(a.shift(1) != True) | (a != False)]
+
     df = pd.concat([df[['time_till_power_up', 'power_up']], a], axis=1, join='inner')
 
     return df

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -95,7 +95,7 @@ def _get_power_up_stats(df: pd.DataFrame, game: Game):
     all_items = dict(_BASE)
 
     if 'power_up_active' in df and 'power_up' in df:
-        df = df[['power_up', 'power_up_active']]
+        df = df[['time_till_power_up', 'power_up', 'power_up_active']]
         df = _squash_power_up_df(df, game)
 
         used_items = df.groupby('power_up')['power_up'].size().to_dict()
@@ -112,7 +112,7 @@ def _squash_power_up_df(df: pd.DataFrame, game: Game):
     a = a.loc[(a.shift(1).isnull() ^ a.isnull()) | ~a.isnull()]
     a = a.loc[(a.shift(1) != a) | (a.shift(-1) != a)]
 
-    df = pd.concat([df['power_up'], a], axis=1, join='inner')
+    df = pd.concat([df[['time_till_power_up', 'power_up']], a], axis=1, join='inner')
 
     mask = []
     prev_false = False

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -32,7 +32,7 @@ class RumbleItemStat(BaseStat):
 
     def calculate_player_stat(self, player_stat_map: Dict[str, PlayerStats], game: Game, proto_game: game_pb2.Game,
                               player_map: Dict[str, Player], data_frame: pd.DataFrame):
-        if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
+        if not is_rumble_enabled(game):
             return
 
         for player_key, stats in player_stat_map.items():
@@ -46,7 +46,7 @@ class RumbleItemStat(BaseStat):
 
     def calculate_team_stat(self, team_stat_list: Dict[int, TeamStats], game: Game, proto_game: game_pb2.Game,
                             player_map: Dict[str, Player], data_frame: pd.DataFrame):
-        if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
+        if not is_rumble_enabled(game):
             return
 
         orange_ids = list(map(lambda x: x.id.id, filter(lambda x: x.is_orange, player_map.values())))
@@ -60,6 +60,17 @@ class RumbleItemStat(BaseStat):
 
         _calculate_rumble_stats(orange_rumble_proto, orange_events, data_frame['game'])
         _calculate_rumble_stats(blue_rumble_proto, blue_events, data_frame['game'])
+
+
+def is_rumble_enabled(game: Game) -> bool:
+    """
+    Check whether rumble is enabled or not.
+
+    :param game: parsed game object
+    :return: True if rumble
+    """
+    return game.game_info.playlist in [RANKED_RUMBLE, UNRANKED_RUMBLE] or \
+           game.game_info.rumble_mutator.startswith('Archetypes.Mutators.SubRules.ItemsMode_')
 
 
 def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rumble_item_events) \

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict
+from typing import Dict, List
 
 import pandas as pd
 
@@ -7,24 +7,24 @@ from carball.generated.api import game_pb2
 from carball.generated.api.player_pb2 import Player
 from carball.generated.api.stats.player_stats_pb2 import PlayerStats
 from carball.generated.api.stats.team_stats_pb2 import TeamStats
+from carball.generated.api.stats.events_pb2 import RumbleItemEvent
 from carball.json_parser.game import Game
 from carball.analysis.stats.stats import BaseStat
 from carball.generated.api.metadata.game_metadata_pb2 import RANKED_RUMBLE, UNRANKED_RUMBLE
 
-_BASE = {
-    'ball_freeze': 0,
-    'ball_grappling_hook': 0,
-    'ball_lasso': 0,
-    'ball_spring': 0,
-    'ball_velcro': 0,
-    'batarang': 0,
-    'boost_override': 0,
-    'car_spring': 0,
-    'gravity_well': 0,
-    'strong_hit': 0,
-    'swapper': 0,
-    'tornado': 0
-}
+POWER_UPS = [
+    'ball_freeze',
+    'ball_grappling_hook',
+    'ball_lasso',
+    'ball_spring',
+    'ball_velcro',
+    'boost_override',
+    'car_spring',
+    'gravity_well',
+    'strong_hit',
+    'swapper',
+    'tornado'
+]
 
 
 class RumbleItemStat(BaseStat):
@@ -38,62 +38,60 @@ class RumbleItemStat(BaseStat):
             player_name = player_map[player_key].name
             player_data_frame = data_frame[player_name]
 
-            _get_power_up_events(player_map[player_key], player_data_frame, game, proto_game.game_stats.rumble_items)
+            events = _get_power_up_events(player_map[player_key], player_data_frame, game,
+                                          proto_game.game_stats.rumble_items)
 
-            rumble_proto = stats.rumble_item_usage
+            rumble_proto = stats.rumble_items
 
-            pass
+            for power_up in POWER_UPS:
+                item_stats = _calculate_rumble_stats(events, power_up, data_frame['game'])
 
-            # rumble_proto.ball_freeze = item_stats['ball_freeze']
-            # rumble_proto.ball_grappling_hook = item_stats['ball_grappling_hook']
-            # rumble_proto.ball_lasso = item_stats['ball_lasso']
-            # rumble_proto.ball_spring = item_stats['ball_spring']
-            # rumble_proto.ball_velcro = item_stats['ball_velcro']
-            # rumble_proto.boost_override = item_stats['boost_override']
-            # rumble_proto.car_spring = item_stats['car_spring']
-            # rumble_proto.gravity_well = item_stats['gravity_well']
-            # rumble_proto.strong_hit = item_stats['strong_hit']
-            # rumble_proto.swapper = item_stats['swapper']
-            # rumble_proto.tornado = item_stats['tornado']
+                rumble_item_proto = getattr(rumble_proto, power_up)
+                rumble_item_proto.used = item_stats['used']
+                rumble_item_proto.unused = item_stats['unused']
+                rumble_item_proto.average_hold = item_stats['average_hold']
 
     def calculate_team_stat(self, team_stat_list: Dict[int, TeamStats], game: Game, proto_game: game_pb2.Game,
                             player_map: Dict[str, Player], data_frame: pd.DataFrame):
-        if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
-            return
+        # if game.game_info.playlist not in [RANKED_RUMBLE, UNRANKED_RUMBLE]:
+        #     return
+        #
+        # for key, team in team_stat_list.items():
+        #     rumble_proto = team.rumble_item_usage
+        #
+        #     rumble_proto.ball_freeze = 0
+        #     rumble_proto.ball_grappling_hook = 0
+        #     rumble_proto.ball_lasso = 0
+        #     rumble_proto.ball_spring = 0
+        #     rumble_proto.ball_velcro = 0
+        #     rumble_proto.boost_override = 0
+        #     rumble_proto.car_spring = 0
+        #     rumble_proto.gravity_well = 0
+        #     rumble_proto.strong_hit = 0
+        #     rumble_proto.swapper = 0
+        #     rumble_proto.tornado = 0
+        #
+        # for key, player in player_map.items():
+        #     rumble_proto = team_stat_list[player.is_orange].rumble_item_usage
+        #     player_rumble_stats = player.stats.rumble_item_usage
+        #
+        #     rumble_proto.ball_freeze += player_rumble_stats.ball_freeze
+        #     rumble_proto.ball_grappling_hook += player_rumble_stats.ball_grappling_hook
+        #     rumble_proto.ball_lasso += player_rumble_stats.ball_lasso
+        #     rumble_proto.ball_spring += player_rumble_stats.ball_spring
+        #     rumble_proto.ball_velcro += player_rumble_stats.ball_velcro
+        #     rumble_proto.boost_override += player_rumble_stats.boost_override
+        #     rumble_proto.car_spring += player_rumble_stats.car_spring
+        #     rumble_proto.gravity_well += player_rumble_stats.gravity_well
+        #     rumble_proto.strong_hit += player_rumble_stats.strong_hit
+        #     rumble_proto.swapper += player_rumble_stats.swapper
+        #     rumble_proto.tornado += player_rumble_stats.tornado
 
-        for key, team in team_stat_list.items():
-            rumble_proto = team.rumble_item_usage
-
-            rumble_proto.ball_freeze = 0
-            rumble_proto.ball_grappling_hook = 0
-            rumble_proto.ball_lasso = 0
-            rumble_proto.ball_spring = 0
-            rumble_proto.ball_velcro = 0
-            rumble_proto.boost_override = 0
-            rumble_proto.car_spring = 0
-            rumble_proto.gravity_well = 0
-            rumble_proto.strong_hit = 0
-            rumble_proto.swapper = 0
-            rumble_proto.tornado = 0
-
-        for key, player in player_map.items():
-            rumble_proto = team_stat_list[player.is_orange].rumble_item_usage
-            player_rumble_stats = player.stats.rumble_item_usage
-
-            rumble_proto.ball_freeze += player_rumble_stats.ball_freeze
-            rumble_proto.ball_grappling_hook += player_rumble_stats.ball_grappling_hook
-            rumble_proto.ball_lasso += player_rumble_stats.ball_lasso
-            rumble_proto.ball_spring += player_rumble_stats.ball_spring
-            rumble_proto.ball_velcro += player_rumble_stats.ball_velcro
-            rumble_proto.boost_override += player_rumble_stats.boost_override
-            rumble_proto.car_spring += player_rumble_stats.car_spring
-            rumble_proto.gravity_well += player_rumble_stats.gravity_well
-            rumble_proto.strong_hit += player_rumble_stats.strong_hit
-            rumble_proto.swapper += player_rumble_stats.swapper
-            rumble_proto.tornado += player_rumble_stats.tornado
+        pass
 
 
-def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rumble_item_events):
+def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rumble_item_events) \
+        -> List[RumbleItemEvent]:
     """
     Finds the item get and item use events
 
@@ -101,13 +99,15 @@ def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rum
     :param df: player dataframe, assumes the frames between goal and kickoff are already discarded
     :param game: game object
     :param proto_rumble_item_events: protobuf repeated api.stats.RumbleItemEvent
+    :return list of rumble events
     """
+    events = []
     if 'power_up_active' in df and 'power_up' in df:
         df = df[['time_till_power_up', 'power_up', 'power_up_active']]
 
         ranges = [(game.kickoff_frames[i], game.kickoff_frames[i + 1]) for i in range(len(game.kickoff_frames) - 1)]
         data_frames = map(lambda x: df.loc[x[0]:x[1] - 1], ranges)
-        data_frames = list(map(_squash_power_up_df, data_frames))
+        data_frames = map(_squash_power_up_df, data_frames)
 
         for data_frame in data_frames:
 
@@ -120,23 +120,28 @@ def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rum
                         # Rumble item get event
                         proto_current_item = proto_rumble_item_events.add()
                         proto_current_item.frame_number_get = i
-                        proto_current_item.item = row['power_up']
+                        proto_current_item.item = 'ball_lasso' if row['power_up'] == 'batarang' else row['power_up']
                         proto_current_item.player_id.id = player.id.id
 
                 elif prev_row['power_up_active'] == False:
-                    if row['power_up_active'] == True:
+                    if row['power_up_active'] == True or \
+                            math.isnan(row['power_up_active']) and prev_row['power_up'] == 'ball_freeze':
                         # Rumble item use event
-                        proto_current_item.frame_number_use = i
-                        proto_current_item = None
-                    elif math.isnan(row['power_up_active']) and prev_row['power_up'] == 'ball_freeze':
                         # When a spiked ball is frozen, there is not 'ball_freeze,True' row, it just gets deleted
                         # immediately
                         # Could also happen when the freeze is immediately broken
                         # in theory this should not happen with other power ups?
                         proto_current_item.frame_number_use = i
+                        events.append(proto_current_item)
                         proto_current_item = None
 
                 prev_row = row
+
+            if proto_current_item is not None:
+                # unused item
+                events.append(proto_current_item)
+
+    return events
 
 
 def _squash_power_up_df(df: pd.DataFrame):
@@ -150,3 +155,29 @@ def _squash_power_up_df(df: pd.DataFrame):
     df = pd.concat([df[['time_till_power_up', 'power_up']], a], axis=1, join='inner')
 
     return df
+
+
+def _calculate_rumble_stats(events: List[RumbleItemEvent], power_up: str, game_df: pd.DataFrame) -> Dict:
+    """
+    Calculate rumble statistics (used, unused, average hold) based on rumble events.
+
+    :param events: list of rumble events
+    :param power_up: name of the power up
+    :param game_df: game dataframe, used for getting the time delta
+    :return: stats
+    """
+    item_events = filter(lambda x: x.item == power_up, events)
+    base = {'used': 0, 'unused': 0, 'average_hold': 0}
+
+    for event in item_events:
+        if event.frame_number_use != -1:
+            base['used'] += 1
+            base['average_hold'] += game_df.loc[event.frame_number_use]['time'] - \
+                                    game_df.loc[event.frame_number_get]['time']
+        else:
+            base['unused'] += 1
+
+    if base['used'] > 0:
+        base['average_hold'] /= base['used']
+
+    return base

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -149,7 +149,7 @@ def _calculate_rumble_stats(rumble_proto: RumbleStats, events: List[RumbleItemEv
     :param events: list of rumble events
     :param game_df: game dataframe, used for getting the time delta
     """
-    for power_up in PowerUp.values():
+    for power_up in set(PowerUp.values()):
         item_stats = _calculate_rumble_stats_for_power_up(events, power_up, game_df)
 
         rumble_item_proto = rumble_proto.rumble_items.add()

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -53,7 +53,7 @@ def is_rumble_enabled(game: Game) -> bool:
     :return: True if rumble
     """
     return game.game_info.playlist in [RANKED_RUMBLE, UNRANKED_RUMBLE] or \
-           game.game_info.rumble_mutator.startswith('Archetypes.Mutators.SubRules.ItemsMode_')
+           game.game_info.rumble_mutator.startswith('Archetypes.Mutators.SubRules.ItemsMode')
 
 
 def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rumble_item_events) \

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -55,8 +55,8 @@ class RumbleItemStat(BaseStat):
         orange_events = list(filter(lambda x: x.player_id.id in orange_ids, proto_game.game_stats.rumble_items))
         blue_events = list(filter(lambda x: x.player_id.id in blue_ids, proto_game.game_stats.rumble_items))
 
-        orange_rumble_proto = team_stat_list[1].rumble_items
-        blue_rumble_proto = team_stat_list[0].rumble_items
+        orange_rumble_proto = team_stat_list[1].rumble_stats.rumble_items
+        blue_rumble_proto = team_stat_list[0].rumble_stats.rumble_items
 
         _calculate_rumble_stats(orange_rumble_proto, orange_events, data_frame['game'])
         _calculate_rumble_stats(blue_rumble_proto, blue_events, data_frame['game'])

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -8,7 +8,7 @@ from carball.generated.api.player_pb2 import Player
 from carball.generated.api.stats.player_stats_pb2 import PlayerStats
 from carball.generated.api.stats.team_stats_pb2 import TeamStats
 from carball.generated.api.stats.events_pb2 import RumbleItemEvent
-from carball.generated.api.stats.rumble_pb2 import PowerUp, RumbleStats, BALL_LASSO
+from carball.generated.api.stats.rumble_pb2 import PowerUp, RumbleStats
 from carball.json_parser.game import Game
 from carball.analysis.stats.stats import BaseStat
 from carball.generated.api.metadata.game_metadata_pb2 import RANKED_RUMBLE, UNRANKED_RUMBLE
@@ -93,6 +93,15 @@ def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rum
                         proto_current_item.frame_number_get = i
                         proto_current_item.item = PowerUp.Value(row['power_up'].upper())
                         proto_current_item.player_id.id = player.id.id
+
+                    if row['power_up_active'] == True:
+                        # immediately used items (mostly bots)
+                        tmp_item = proto_rumble_item_events.add()
+                        tmp_item.frame_number_get = i
+                        tmp_item.frame_number_use = i
+                        tmp_item.item = PowerUp.Value(row['power_up'].upper())
+                        tmp_item.player_id.id = player.id.id
+                        events.append(tmp_item)
 
                 elif prev_row['power_up_active'] == False:
                     if row['power_up_active'] == True or \

--- a/carball/analysis/stats/rumble/rumble.py
+++ b/carball/analysis/stats/rumble/rumble.py
@@ -86,8 +86,7 @@ def _get_power_up_events(player: Player, df: pd.DataFrame, game: Game, proto_rum
                         # Rumble item get event
                         proto_current_item = proto_rumble_item_events.add()
                         proto_current_item.frame_number_get = i
-                        proto_current_item.item = BALL_LASSO if row['power_up'] == 'batarang' else \
-                            PowerUp.Value(row['power_up'].upper())
+                        proto_current_item.item = PowerUp.Value(row['power_up'].upper())
                         proto_current_item.player_id.id = player.id.id
 
                 elif prev_row['power_up_active'] == False:

--- a/carball/analysis/stats/stats_list.py
+++ b/carball/analysis/stats/stats_list.py
@@ -15,7 +15,7 @@ from carball.analysis.stats.tendencies.relative_position_tendencies import Relat
 from carball.analysis.stats.tendencies.speed_tendencies import SpeedTendencies
 from carball.analysis.stats.tendencies.team_tendencies import TeamTendencies
 from carball.analysis.stats.rumble.rumble import RumbleItemStat
-from carball.analysis.stats.rumble.goals import PreRumbleGoals
+from carball.analysis.stats.rumble.goals import PreRumbleGoals, ItemGoals
 
 
 class StatsList:
@@ -52,7 +52,8 @@ class StatsList:
     def get_general_stats() ->List[BaseStat]:
         """These are stats that end up being assigned to the game as a whole"""
         return [PositionalTendencies(),
-                SpeedTendencies()
+                SpeedTendencies(),
+                ItemGoals()
                 ]
 
     @staticmethod

--- a/carball/analysis/stats/stats_list.py
+++ b/carball/analysis/stats/stats_list.py
@@ -13,6 +13,7 @@ from ...analysis.stats.possession.turnovers import TurnoverStat
 from ...analysis.stats.stats import BaseStat, HitStat
 from ...analysis.stats.tendencies.positional_tendencies import PositionalTendencies
 from ...analysis.stats.controls.controls import ControlsStat
+from ...analysis.stats.rumble.rumble import RumbleItemStat
 
 
 class StatsList:
@@ -28,7 +29,8 @@ class StatsList:
                 Averages(),
                 BallDistanceStat(),
                 ControlsStat(),
-                SpeedTendencies()
+                SpeedTendencies(),
+                RumbleItemStat()
                 ]
 
     @staticmethod
@@ -36,7 +38,8 @@ class StatsList:
         """These are stats that end up being assigned to a specific team"""
         return [PossessionStat(),
                 TeamTendencies(),
-                RelativeTendencies()]
+                RelativeTendencies(),
+                RumbleItemStat()]
 
     @staticmethod
     def get_general_stats() ->List[BaseStat]:

--- a/carball/analysis/stats/stats_list.py
+++ b/carball/analysis/stats/stats_list.py
@@ -15,6 +15,7 @@ from carball.analysis.stats.tendencies.relative_position_tendencies import Relat
 from carball.analysis.stats.tendencies.speed_tendencies import SpeedTendencies
 from carball.analysis.stats.tendencies.team_tendencies import TeamTendencies
 from carball.analysis.stats.rumble.rumble import RumbleItemStat
+from carball.analysis.stats.rumble.goals import PreRumbleGoals
 
 
 class StatsList:
@@ -43,7 +44,8 @@ class StatsList:
                 TeamTendencies(),
                 RelativeTendencies(),
                 PerPossessionStat(),
-                RumbleItemStat()
+                RumbleItemStat(),
+                PreRumbleGoals()
                 ]
 
     @staticmethod

--- a/carball/json_parser/game.py
+++ b/carball/json_parser/game.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from datetime import datetime
 from typing import List
 
@@ -562,6 +563,8 @@ class Game:
                                 player_actor_id = car_player_ids[car_actor_id]
                                 item_name = actor_data['TypeName'] \
                                     .replace('Archetypes.SpecialPickups.SpecialPickup_', '')
+                                # CamelCase to snake_case
+                                item_name = re.sub('([A-Z]+)', r'_\1', item_name).lower()[1:]
                                 # item is active when this is odd
                                 item_active = actor_data.get(COMPONENT_REPLICATED_ACTIVE_KEY, 0) % 2 == 1
 

--- a/carball/json_parser/game.py
+++ b/carball/json_parser/game.py
@@ -565,6 +565,7 @@ class Game:
             'cameras_data': cameras_data,
             'demos_data': demos_data,
             'game_info_actor': game_info_actor,
+            'soccar_game_event_actor': current_actors[soccar_game_event_actor_id],
             'parties': parties
         }
 
@@ -672,7 +673,9 @@ class Game:
         :return:
         """
         # GAME INFO
-        self.game_info = GameInfo().parse_game_info_actor(all_data['game_info_actor'])
+        self.game_info = GameInfo().parse_game_info_actor(all_data['game_info_actor'],
+                                                          all_data['soccar_game_event_actor'],
+                                                          self.replay['content']['body']['objects'])
 
         # TEAMS
         self.teams = []

--- a/carball/json_parser/game.py
+++ b/carball/json_parser/game.py
@@ -553,6 +553,21 @@ class Game:
                                 # it does not turn back false immediately although boost is only collected once.
                                 # using actor_id!=-1
                                 actor_data[REPLICATED_PICKUP_KEY]['pickup']["instigator_id"] = -1
+
+                    # rumble items
+                    elif actor_data['TypeName'].startswith('Archetypes.SpecialPickups.SpecialPickup_'):
+                        car_actor_id = actor_data.get('TAGame.CarComponent_TA:Vehicle', None)
+                        if car_actor_id is not None:
+                            if car_actor_id in current_car_ids_to_collect:
+                                player_actor_id = car_player_ids[car_actor_id]
+                                item_name = actor_data['TypeName'] \
+                                    .replace('Archetypes.SpecialPickups.SpecialPickup_', '')
+                                # item is active when this is odd
+                                item_active = actor_data.get(COMPONENT_REPLICATED_ACTIVE_KEY, 0) % 2 == 1
+
+                                player_ball_data[player_actor_id][frame_number]['power_up'] = item_name
+                                player_ball_data[player_actor_id][frame_number]['power_up_active'] = item_active
+
                 for player_actor_id in player_dicts:
                     actor_data = current_actors.get(player_actor_id, None)
                     if actor_data is None:

--- a/carball/json_parser/game_info.py
+++ b/carball/json_parser/game_info.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -10,11 +11,14 @@ class GameInfo:
         self.match_guid = None
         self.game_mode = None
         self.mutator_index = None
+        self.rumble_mutator = None
 
-    def parse_game_info_actor(self, actor_data: dict):
+    def parse_game_info_actor(self, actor_data: dict, game_event_actor: dict, objects: List[str]):
         """
         Parses game actor
         :param actor_data: game replication info
+        :param game_event_actor: soccar game event actor
+        :param objects: object list from the decompiled replay
         :return: self
         """        
         # There is no GameServerID if you play alone
@@ -27,6 +31,11 @@ class GameInfo:
         self.match_guid = actor_data.get('ProjectX.GRI_X:MatchGUID', '')
         self.playlist = actor_data['ProjectX.GRI_X:ReplicatedGamePlaylist']
         self.mutator_index = actor_data.get('ProjectX.GRI_X:ReplicatedGameMutatorIndex', 0)
+
+        if 'TAGame.GameEvent_Soccar_TA:SubRulesArchetype' in game_event_actor:
+            # Only used for rumble stats
+            # TODO can this contain any other mutators?
+            self.rumble_mutator = objects[game_event_actor['TAGame.GameEvent_Soccar_TA:SubRulesArchetype']]
 
         logger.info('Created game info from actor')
         return self

--- a/carball/json_parser/player.py
+++ b/carball/json_parser/player.py
@@ -163,7 +163,7 @@ class Player:
         ['ping', 'pos_x', 'pos_y', 'pos_z', 'rot_x', 'rot_y', 'rot_z', 'vel_x',
         'vel_y', 'vel_z', 'ang_vel_x', 'ang_vel_y', 'ang_vel_z', 'throttle',
         'steer', 'handbrake', 'ball_cam', 'dodge_active', 'double_jump_active',
-        'jump_active', 'boost', 'boost_active']
+        'jump_active', 'boost', 'boost_active', 'power_up', 'power_up_active']
 
         {'ang_vel_x': dtype('float64'),
          'ang_vel_y': dtype('float64'),
@@ -186,7 +186,9 @@ class Player:
          'throttle': dtype('float64'),
          'vel_x': dtype('float64'),
          'vel_y': dtype('float64'),
-         'vel_z': dtype('float64')}
+         'vel_z': dtype('float64'),
+         'power_up': dtype('O'),
+         'power_up_active': dtype('O')}
 
         :param _dict:
         :return:

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -2,8 +2,7 @@ import unittest
 
 from carball.analysis.analysis_manager import AnalysisManager
 
-from carball.tests.utils import run_analysis_test_on_replay, get_raw_replays, get_specific_answers, \
-    assertNearlyEqual
+from carball.tests.utils import run_analysis_test_on_replay, get_raw_replays
 
 from carball.generated.api.stats.rumble_pb2 import *
 
@@ -37,3 +36,15 @@ class RumbleTest(unittest.TestCase):
             self.assertFalse(goals[5].rumble_info.scored_with_item)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_ITEM_GOALS"])
+
+    def test_freeze_vs_spike(self):
+        def test(analysis: AnalysisManager):
+            proto_game = analysis.get_protobuf_data()
+
+            self.assertNotEquals(proto_game.game_stats.rumble_items[1].frame_number_use, -1)
+
+            freeze_stats = next(filter(lambda x: x.item == BALL_FREEZE,
+                                       proto_game.players[0].stats.rumble_stats.rumble_items))
+            self.assertEquals(freeze_stats.used, 1)
+
+        run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_FREEZE_VS_SPIKE"])

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -5,6 +5,8 @@ from carball.analysis.analysis_manager import AnalysisManager
 from carball.tests.utils import run_analysis_test_on_replay, get_raw_replays, get_specific_answers, \
     assertNearlyEqual
 
+from carball.generated.api.stats.rumble_pb2 import *
+
 
 class RumbleTest(unittest.TestCase):
 
@@ -17,3 +19,21 @@ class RumbleTest(unittest.TestCase):
             self.assertTrue(proto_game.game_metadata.goals[2].rumble_info.pre_items)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_PRE_ITEM_GOALS"])
+
+    def test_item_goals(self):
+        def test(analysis: AnalysisManager):
+            proto_game = analysis.get_protobuf_data()
+            goals = proto_game.game_metadata.goals
+
+            for i in range(5):
+                self.assertTrue(goals[i].rumble_info.scored_with_item)
+
+            self.assertEqual(goals[0].rumble_info.used_item, GRAVITY_WELL)
+            self.assertEqual(goals[1].rumble_info.used_item, BALL_GRAPPLING_HOOK)
+            self.assertEqual(goals[2].rumble_info.used_item, STRONG_HIT)
+            self.assertEqual(goals[3].rumble_info.used_item, BALL_VELCRO)
+            self.assertEqual(goals[4].rumble_info.used_item, BALL_LASSO)
+
+            self.assertFalse(goals[5].rumble_info.scored_with_item)
+
+        run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_ITEM_GOALS"])

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -62,3 +62,133 @@ class RumbleTest(unittest.TestCase):
             self.assertAlmostEquals(spike_stats.average_hold, 11.87916, 5)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_HOLD_TIME"])
+
+    def test_item_count(self):
+        def test(analysis: AnalysisManager):
+            proto_game = analysis.get_protobuf_data()
+
+            self.assert_rumble_item_counts(proto_game.players[0].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 1, 'unused': 0},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 1, 'unused': 0},
+                {'item': BALL_LASSO, 'used': 1, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 2, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 0, 'unused': 1},
+                {'item': BOOST_OVERRIDE, 'used': 2, 'unused': 0},
+                {'item': CAR_SPRING, 'used': 1, 'unused': 1},
+                {'item': GRAVITY_WELL, 'used': 2, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 2, 'unused': 0},
+                {'item': SWAPPER, 'used': 1, 'unused': 0},
+                {'item': TORNADO, 'used': 0, 'unused': 0}
+            ])
+
+            self.assert_rumble_item_counts(proto_game.players[1].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 2, 'unused': 0},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 1, 'unused': 1},
+                {'item': BALL_LASSO, 'used': 1, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 1, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 0, 'unused': 1},
+                {'item': BOOST_OVERRIDE, 'used': 2, 'unused': 0},
+                {'item': CAR_SPRING, 'used': 0, 'unused': 1},
+                {'item': GRAVITY_WELL, 'used': 2, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 1, 'unused': 0},
+                {'item': SWAPPER, 'used': 2, 'unused': 0},
+                {'item': TORNADO, 'used': 0, 'unused': 1}
+            ])
+
+            self.assert_rumble_item_counts(proto_game.players[2].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 1, 'unused': 0},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 0, 'unused': 0},
+                {'item': BALL_LASSO, 'used': 2, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 1, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 1, 'unused': 1},
+                {'item': BOOST_OVERRIDE, 'used': 1, 'unused': 1},
+                {'item': CAR_SPRING, 'used': 0, 'unused': 0},
+                {'item': GRAVITY_WELL, 'used': 2, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 2, 'unused': 0},
+                {'item': SWAPPER, 'used': 1, 'unused': 1},
+                {'item': TORNADO, 'used': 1, 'unused': 0}
+            ])
+
+            self.assert_rumble_item_counts(proto_game.players[3].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 0, 'unused': 1},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 1, 'unused': 1},
+                {'item': BALL_LASSO, 'used': 1, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 1, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 1, 'unused': 0},
+                {'item': BOOST_OVERRIDE, 'used': 2, 'unused': 0},
+                {'item': CAR_SPRING, 'used': 2, 'unused': 0},
+                {'item': GRAVITY_WELL, 'used': 1, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 1, 'unused': 0},
+                {'item': SWAPPER, 'used': 2, 'unused': 0},
+                {'item': TORNADO, 'used': 0, 'unused': 0}
+            ])
+
+            self.assert_rumble_item_counts(proto_game.players[4].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 2, 'unused': 0},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 2, 'unused': 0},
+                {'item': BALL_LASSO, 'used': 2, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 0, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 1, 'unused': 0},
+                {'item': BOOST_OVERRIDE, 'used': 2, 'unused': 0},
+                {'item': CAR_SPRING, 'used': 1, 'unused': 0},
+                {'item': GRAVITY_WELL, 'used': 2, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 1, 'unused': 0},
+                {'item': SWAPPER, 'used': 1, 'unused': 1},
+                {'item': TORNADO, 'used': 0, 'unused': 0}
+            ])
+
+            self.assert_rumble_item_counts(proto_game.players[5].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 2, 'unused': 0},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 2, 'unused': 0},
+                {'item': BALL_LASSO, 'used': 2, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 1, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 1, 'unused': 0},
+                {'item': BOOST_OVERRIDE, 'used': 1, 'unused': 0},
+                {'item': CAR_SPRING, 'used': 2, 'unused': 0},
+                {'item': GRAVITY_WELL, 'used': 0, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 2, 'unused': 0},
+                {'item': SWAPPER, 'used': 1, 'unused': 1},
+                {'item': TORNADO, 'used': 1, 'unused': 0}
+            ])
+
+            self.assert_rumble_item_counts(proto_game.teams[0].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 2, 'unused': 1},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 2, 'unused': 1},
+                {'item': BALL_LASSO, 'used': 4, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 4, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 2, 'unused': 2},
+                {'item': BOOST_OVERRIDE, 'used': 5, 'unused': 1},
+                {'item': CAR_SPRING, 'used': 3, 'unused': 1},
+                {'item': GRAVITY_WELL, 'used': 5, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 5, 'unused': 0},
+                {'item': SWAPPER, 'used': 4, 'unused': 1},
+                {'item': TORNADO, 'used': 1, 'unused': 0}
+            ])
+
+            self.assert_rumble_item_counts(proto_game.teams[1].stats.rumble_stats, [
+                {'item': BALL_FREEZE, 'used': 6, 'unused': 0},
+                {'item': BALL_GRAPPLING_HOOK, 'used': 5, 'unused': 1},
+                {'item': BALL_LASSO, 'used': 5, 'unused': 0},
+                {'item': BALL_SPRING, 'used': 2, 'unused': 0},
+                {'item': BALL_VELCRO, 'used': 2, 'unused': 1},
+                {'item': BOOST_OVERRIDE, 'used': 5, 'unused': 0},
+                {'item': CAR_SPRING, 'used': 3, 'unused': 1},
+                {'item': GRAVITY_WELL, 'used': 4, 'unused': 0},
+                {'item': STRONG_HIT, 'used': 4, 'unused': 0},
+                {'item': SWAPPER, 'used': 4, 'unused': 2},
+                {'item': TORNADO, 'used': 1, 'unused': 1}
+            ])
+
+        run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_FULL"])
+
+    def assert_rumble_item_counts(self, rumble_stats_proto, expected):
+        result_stats = list(map(proto_to_dict, rumble_stats_proto.rumble_items))
+        self.assertCountEqual(result_stats, expected)
+
+
+def proto_to_dict(item_proto):
+    return {
+        'item': item_proto.item,
+        'used': item_proto.used,
+        'unused': item_proto.unused
+    }

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -4,7 +4,7 @@ from carball.analysis.analysis_manager import AnalysisManager
 
 from carball.tests.utils import run_analysis_test_on_replay, get_raw_replays
 
-from carball.generated.api.stats.rumble_pb2 import *
+from carball.generated.api.stats.extra_mode_stats_pb2 import *
 
 
 class RumbleTest(unittest.TestCase):

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -48,3 +48,17 @@ class RumbleTest(unittest.TestCase):
             self.assertEquals(freeze_stats.used, 1)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_FREEZE_VS_SPIKE"])
+
+    def test_hold_time(self):
+        def test(analysis: AnalysisManager):
+            proto_game = analysis.get_protobuf_data()
+
+            spike_stats = next(filter(lambda x: x.item == BALL_VELCRO,
+                                      proto_game.players[0].stats.rumble_stats.rumble_items))
+            self.assertAlmostEquals(spike_stats.average_hold, 11.87916, 5)
+
+            spike_stats = next(filter(lambda x: x.item == BALL_VELCRO,
+                                      proto_game.teams[0].stats.rumble_stats.rumble_items))
+            self.assertAlmostEquals(spike_stats.average_hold, 11.87916, 5)
+
+        run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_HOLD_TIME"])

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -13,9 +13,9 @@ class RumbleTest(unittest.TestCase):
         def test(analysis: AnalysisManager):
             proto_game = analysis.get_protobuf_data()
 
-            self.assertTrue(proto_game.game_metadata.goals[0].rumble_info.pre_items)
-            self.assertFalse(proto_game.game_metadata.goals[1].rumble_info.pre_items)
-            self.assertTrue(proto_game.game_metadata.goals[2].rumble_info.pre_items)
+            self.assertTrue(proto_game.game_metadata.goals[0].extra_mode_info.pre_items)
+            self.assertFalse(proto_game.game_metadata.goals[1].extra_mode_info.pre_items)
+            self.assertTrue(proto_game.game_metadata.goals[2].extra_mode_info.pre_items)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_PRE_ITEM_GOALS"])
 
@@ -25,15 +25,15 @@ class RumbleTest(unittest.TestCase):
             goals = proto_game.game_metadata.goals
 
             for i in range(5):
-                self.assertTrue(goals[i].rumble_info.scored_with_item)
+                self.assertTrue(goals[i].extra_mode_info.scored_with_item)
 
-            self.assertEqual(goals[0].rumble_info.used_item, GRAVITY_WELL)
-            self.assertEqual(goals[1].rumble_info.used_item, BALL_GRAPPLING_HOOK)
-            self.assertEqual(goals[2].rumble_info.used_item, STRONG_HIT)
-            self.assertEqual(goals[3].rumble_info.used_item, BALL_VELCRO)
-            self.assertEqual(goals[4].rumble_info.used_item, BALL_LASSO)
+            self.assertEqual(goals[0].extra_mode_info.used_item, GRAVITY_WELL)
+            self.assertEqual(goals[1].extra_mode_info.used_item, BALL_GRAPPLING_HOOK)
+            self.assertEqual(goals[2].extra_mode_info.used_item, STRONG_HIT)
+            self.assertEqual(goals[3].extra_mode_info.used_item, BALL_VELCRO)
+            self.assertEqual(goals[4].extra_mode_info.used_item, BALL_LASSO)
 
-            self.assertFalse(goals[5].rumble_info.scored_with_item)
+            self.assertFalse(goals[5].extra_mode_info.scored_with_item)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_ITEM_GOALS"])
 

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -41,11 +41,11 @@ class RumbleTest(unittest.TestCase):
         def test(analysis: AnalysisManager):
             proto_game = analysis.get_protobuf_data()
 
-            self.assertNotEquals(proto_game.game_stats.rumble_items[1].frame_number_use, -1)
+            self.assertNotEqual(proto_game.game_stats.rumble_items[1].frame_number_use, -1)
 
             freeze_stats = next(filter(lambda x: x.item == BALL_FREEZE,
                                        proto_game.players[0].stats.rumble_stats.rumble_items))
-            self.assertEquals(freeze_stats.used, 1)
+            self.assertEqual(freeze_stats.used, 1)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_FREEZE_VS_SPIKE"])
 
@@ -55,11 +55,11 @@ class RumbleTest(unittest.TestCase):
 
             spike_stats = next(filter(lambda x: x.item == BALL_VELCRO,
                                       proto_game.players[0].stats.rumble_stats.rumble_items))
-            self.assertAlmostEquals(spike_stats.average_hold, 11.87916, 5)
+            self.assertAlmostEqual(spike_stats.average_hold, 11.87916, 5)
 
             spike_stats = next(filter(lambda x: x.item == BALL_VELCRO,
                                       proto_game.teams[0].stats.rumble_stats.rumble_items))
-            self.assertAlmostEquals(spike_stats.average_hold, 11.87916, 5)
+            self.assertAlmostEqual(spike_stats.average_hold, 11.87916, 5)
 
         run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_HOLD_TIME"])
 

--- a/carball/tests/stats/rumble_test.py
+++ b/carball/tests/stats/rumble_test.py
@@ -1,0 +1,19 @@
+import unittest
+
+from carball.analysis.analysis_manager import AnalysisManager
+
+from carball.tests.utils import run_analysis_test_on_replay, get_raw_replays, get_specific_answers, \
+    assertNearlyEqual
+
+
+class RumbleTest(unittest.TestCase):
+
+    def test_pre_item_goals(self):
+        def test(analysis: AnalysisManager):
+            proto_game = analysis.get_protobuf_data()
+
+            self.assertTrue(proto_game.game_metadata.goals[0].rumble_info.pre_items)
+            self.assertFalse(proto_game.game_metadata.goals[1].rumble_info.pre_items)
+            self.assertTrue(proto_game.game_metadata.goals[2].rumble_info.pre_items)
+
+        run_analysis_test_on_replay(test, get_raw_replays()["RUMBLE_PRE_ITEM_GOALS"])

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -189,6 +189,9 @@ def get_raw_replays():
         "RUMBLE_HOLD_TIME": [
             "https://cdn.discordapp.com/attachments/493849514680254468/568554413283868702/RUMBLE_HOLD_TIME.replay"
         ],
+        "RUMBLE_FULL": [
+            "https://cdn.discordapp.com/attachments/493849514680254468/568555561160015889/RUMBLE_FULL.replay"
+        ],
     }
 
 

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -175,6 +175,11 @@ def get_raw_replays():
             "https://cdn.discordapp.com/attachments/493849514680254468/561300088400379905/crossplatform_party.replay"],
         "PARTY_LEADER_SYSTEM_ID_0_ERROR": [
             'https://cdn.discordapp.com/attachments/493849514680254468/563036945635082260/PARTY_LEADER_SYSTEM_ID_0.replay'],
+
+        # rumble
+        "RUMBLE_PRE_ITEM_GOALS": [
+            "https://cdn.discordapp.com/attachments/493849514680254468/568540280937250836/RUMBLE_PRE_ITEM_GOALS.replay"
+        ],
     }
 
 

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -180,6 +180,9 @@ def get_raw_replays():
         "RUMBLE_PRE_ITEM_GOALS": [
             "https://cdn.discordapp.com/attachments/493849514680254468/568540280937250836/RUMBLE_PRE_ITEM_GOALS.replay"
         ],
+        "RUMBLE_ITEM_GOALS": [
+            "https://cdn.discordapp.com/attachments/493849514680254468/568542870441558017/RUMBLE_ITEM_GOALS.replay"
+        ],
     }
 
 

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -186,6 +186,9 @@ def get_raw_replays():
         "RUMBLE_FREEZE_VS_SPIKE": [
             "https://cdn.discordapp.com/attachments/493849514680254468/568546468777033773/RUMBLE_FREEZE_VS_SPIKE.replay"
         ],
+        "RUMBLE_HOLD_TIME": [
+            "https://cdn.discordapp.com/attachments/493849514680254468/568554413283868702/RUMBLE_HOLD_TIME.replay"
+        ],
     }
 
 

--- a/carball/tests/utils.py
+++ b/carball/tests/utils.py
@@ -183,6 +183,9 @@ def get_raw_replays():
         "RUMBLE_ITEM_GOALS": [
             "https://cdn.discordapp.com/attachments/493849514680254468/568542870441558017/RUMBLE_ITEM_GOALS.replay"
         ],
+        "RUMBLE_FREEZE_VS_SPIKE": [
+            "https://cdn.discordapp.com/attachments/493849514680254468/568546468777033773/RUMBLE_FREEZE_VS_SPIKE.replay"
+        ],
     }
 
 


### PR DESCRIPTION
Add rumble statistics

- Event proto for rumble items (get time, use time, player id)
- Per player and per team item stats (used, unused, average hold time)
- Added 'scored before rumble items' to Goal proto
- Added 'used item' to Goal proto (has to be active in a 3 sec time frame before the goal

TODO test cases (manually evaluated replays)
Possible edge cases to test:
- Spike broken by a freeze, the freeze has no active state (I have a replay for this)
- ???