### PR TITLE
handle numpy datatypes when serializing to json

### DIFF
--- a/carball/analysis/analysis_manager.py
+++ b/carball/analysis/analysis_manager.py
@@ -6,6 +6,8 @@ import pandas as pd
 import json
 import os
 
+from google.protobuf.json_format import _Printer
+from .utils.json_encoder import CarballJsonEncoder
 
 script_path = os.path.abspath(__file__)
 with open(os.path.join(os.path.dirname(script_path), 'PROTOBUF_VERSION'), 'r') as f:
@@ -211,3 +213,8 @@ class AnalysisManager:
         #     return False
 
         return True
+
+    def write_json_out_to_file(self, file):
+        printer = _Printer()
+        js = printer._MessageToJsonObject(self.protobuf_game)
+        json.dump(js, file, indent=2, cls=CarballJsonEncoder)

--- a/carball/analysis/utils/json_encoder.py
+++ b/carball/analysis/utils/json_encoder.py
@@ -1,0 +1,10 @@
+import json
+import numpy as np
+
+
+class CarballJsonEncoder(json.JSONEncoder):
+    def default(self, o):
+        # it cannot normally serialize np.int64 and possibly other np data types
+        if type(o).__module__ == np.__name__:
+            return o.item()
+        return super(CarballJsonEncoder, self).default(o)

--- a/carball/command_line.py
+++ b/carball/command_line.py
@@ -2,19 +2,8 @@ import argparse
 import carball
 import logging
 import gzip
-import json
-import numpy as np
 from carball.json_parser.game import Game
 from carball.analysis.analysis_manager import AnalysisManager
-from google.protobuf.json_format import _Printer
-
-
-class CarballJsonEncoder(json.JSONEncoder):
-    def default(self, o):
-        # it cannot normally serialize np.int64 and possibly other np data types
-        if type(o).__module__ == np.__name__:
-            return o.item()
-        return super(CarballJsonEncoder, self).default(o)
 
 
 def main():
@@ -65,11 +54,8 @@ def main():
         with open(args.proto, 'wb') as f:
             manager.write_proto_out_to_file(f)
     if args.json:
-        proto_game = manager.get_protobuf_data()
         with open(args.json, 'w') as f:
-            printer = _Printer()
-            js = printer._MessageToJsonObject(proto_game)
-            json.dump(js, f, indent=2, cls=CarballJsonEncoder)
+            manager.write_json_out_to_file(f)
     if args.gzip:
         with gzip.open(args.gzip, 'wb') as f:
             manager.write_pandas_out_to_file(f)

--- a/carball/tests/export_test.py
+++ b/carball/tests/export_test.py
@@ -1,0 +1,13 @@
+from tempfile import NamedTemporaryFile
+from carball.analysis.analysis_manager import AnalysisManager
+from carball.tests.utils import run_analysis_test_on_replay, get_raw_replays
+
+
+class Test_Export():
+
+    def test_json_export(self, replay_cache):
+        def test(analysis: AnalysisManager):
+            with NamedTemporaryFile(mode='w') as f:
+                analysis.write_json_out_to_file(f)
+
+        run_analysis_test_on_replay(test, get_raw_replays()["DEFAULT_3_ON_3_AROUND_58_HITS"], cache=replay_cache)


### PR DESCRIPTION
The built in json module fails to serialize certain numpy data types (e.g. int64)