### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     version=version_string,
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=['pandas==0.24.2', 'protobuf==3.6.1', 'xlrd==1.1.0', 'numpy==1.17.0', 'boxcars-py==0.1.3'],
+    install_requires=['pandas==1.0.3', 'protobuf==3.6.1', 'xlrd==1.1.0', 'numpy==1.18.2', 'boxcars-py==0.1.*'],
     url='https://github.com/SaltieRL/carball',
     keywords=['rocket-league'],
     license='Apache 2.0',


### PR DESCRIPTION
sync up the versions between requirements.txt and setup.py

```
PS C:\Users\lngtr> pip install boxcars-py -U
Collecting boxcars-py
  Using cached boxcars_py-0.1.4-cp38-none-win_amd64.whl (402 kB)
ERROR: carball 0.7.1 has requirement boxcars-py==0.1.3, but you'll have boxcars-py 0.1.4 which is incompatible.
ERROR: carball 0.7.1 has requirement numpy==1.17.0, but you'll have numpy 1.19.1 which is incompatible.
ERROR: carball 0.7.1 has requirement pandas==0.24.2, but you'll have pandas 1.0.3 which is incompatible.
Installing collected packages: boxcars-py
  Attempting uninstall: boxcars-py
    Found existing installation: boxcars-py 0.1.3
    Uninstalling boxcars-py-0.1.3:
      Successfully uninstalled boxcars-py-0.1.3
Successfully installed boxcars-py-0.1.4
```